### PR TITLE
feat(deploy): switch docker-compose nginx to SSL config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,11 +93,12 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
-      - ./nginx/ssl:/etc/nginx/ssl:ro
+      - ./nginx/ssl.conf:/etc/nginx/conf.d/default.conf:ro
+      - /etc/letsencrypt:/etc/letsencrypt:ro
+      - certbot_webroot:/var/www/certbot:ro
       - media_data:/app/media:ro
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost/ || exit 1"]
+      test: ["CMD-SHELL", "curl -sfk https://localhost/ || exit 1"]
       interval: 30s
       timeout: 5s
       retries: 3
@@ -108,6 +109,7 @@ services:
 volumes:
   postgres_data:
   media_data:
+  certbot_webroot:
 
 networks:
   internal:


### PR DESCRIPTION
Use nginx/ssl.conf instead of default.conf so the production stack terminates TLS at nginx. Mounts the host Let's Encrypt certificates and adds a certbot_webroot volume for ACME challenge renewals. Updates the nginx healthcheck to use HTTPS with -k (self-signed safe).