### PR TITLE
fix(deploy): mount tinyboards.hjson to its own path in containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,12 +36,12 @@ services:
       postgres:
         condition: service_healthy
     environment:
-      TB_CONFIG_LOCATION: /app/config/defaults.hjson
+      TB_CONFIG_LOCATION: /app/config/tinyboards.hjson
       RUST_LOG: ${RUST_LOG:-info}
       TLS_ENABLED: ${TLS_ENABLED:-false}
     volumes:
       - media_data:/app/media
-      - ./tinyboards.hjson:/app/config/defaults.hjson:ro
+      - ./tinyboards.hjson:/app/config/tinyboards.hjson:ro
     expose:
       - "8536"
     healthcheck:
@@ -61,7 +61,7 @@ services:
         condition: service_healthy
     environment:
       # The frontend reads tinyboards.hjson directly at startup.
-      TB_CONFIG_LOCATION: /app/config/defaults.hjson
+      TB_CONFIG_LOCATION: /app/config/tinyboards.hjson
       # Nuxt runtimeConfig overrides — these take effect at runtime even though
       # nuxt.config.ts bakes defaults at build time. All three must be set
       # because internalGqlHost is derived from internalApiHost during build.
@@ -69,7 +69,7 @@ services:
       NUXT_BACKEND_URL: http://backend:8536
       NUXT_INTERNAL_GQL_HOST: http://backend:8536/api/v2/graphql
     volumes:
-      - ./tinyboards.hjson:/app/config/defaults.hjson:ro
+      - ./tinyboards.hjson:/app/config/tinyboards.hjson:ro
     expose:
       - "3000"
     healthcheck:


### PR DESCRIPTION
Mount to /app/config/tinyboards.hjson instead of shadowing /app/config/defaults.hjson. This avoids the issue where Docker silently creates an empty directory if the host file is missing, causing the backend to fall back to baked-in defaults and ignore the user's configuration.