### PR TITLE
fix(deploy): set database host to postgres in defaults.hjson

### DIFF
--- a/backend/config/defaults.hjson
+++ b/backend/config/defaults.hjson
@@ -5,8 +5,8 @@
     user: "tinyboards"
     # Password to connect to postgres
     password: "tinyboards"
-    # Host where postgres is running
-    host: "127.0.0.1"
+    # Host where postgres is running (use "postgres" for Docker Compose)
+    host: "postgres"
     # Port where postgres can be accessed
     port: 5432
     # Name of the postgres database for tinyboards


### PR DESCRIPTION
The baked-in defaults.hjson had host: "127.0.0.1" which does not resolve to the postgres container inside Docker Compose. Changed to "postgres" to match the compose service name so the backend can connect when no tinyboards.hjson overrides the value.