### PR TITLE
fix(api): use User::from_db instead of From trait in stream resolver

### DIFF
--- a/backend/crates/api/src/structs/stream.rs
+++ b/backend/crates/api/src/structs/stream.rs
@@ -89,7 +89,7 @@ impl Stream {
             .await
             .ok();
 
-        Ok(user.map(|u| User::from(u)))
+        Ok(user.map(|u| User::from_db(u, None)))
     }
 
     /// Follower count from aggregates


### PR DESCRIPTION
The stream creator resolver was calling User::from() which doesn't exist for the API User struct. Use from_db(user, None) to match the pattern used by DataLoaders throughout the codebase.