### PR TITLE
feat(profile): add tabbed navigation with overview, saved, and follow…

### DIFF
--- a/frontend/components/user/UserActions.vue
+++ b/frontend/components/user/UserActions.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, onMounted } from 'vue'
 import { useGraphQL } from '~/composables/useGraphQL'
 import { useToast } from '~/composables/useToast'
+import { useAuthStore } from '~/stores/auth'
 import type { User } from '~/types/generated'
 
 const props = defineProps<{
@@ -9,15 +10,28 @@ const props = defineProps<{
 }>()
 
 const toast = useToast()
+const authStore = useAuthStore()
 
 const FOLLOW_MUTATION = `mutation FollowUser($userId: ID!) { followUser(userId: $userId) }`
 const UNFOLLOW_MUTATION = `mutation UnfollowUser($userId: ID!) { unfollowUser(userId: $userId) }`
 const BLOCK_MUTATION = `mutation BlockUser($userId: ID!) { blockUser(userId: $userId) }`
 const UNBLOCK_MUTATION = `mutation UnblockUser($userId: ID!) { unblockUser(userId: $userId) }`
+const IS_FOLLOWING_QUERY = `query IsFollowing($userId: ID!) { isFollowingUser(userId: $userId) }`
 
 const isFollowing = ref(false)
 const isBlocked = ref(false)
 const acting = ref(false)
+
+interface IsFollowingResponse { isFollowingUser: boolean }
+
+onMounted(async () => {
+  if (!authStore.user) return
+  const { execute } = useGraphQL<IsFollowingResponse>()
+  const result = await execute(IS_FOLLOWING_QUERY, { variables: { userId: props.user.id } })
+  if (result) {
+    isFollowing.value = result.isFollowingUser
+  }
+})
 
 async function toggleFollow (): Promise<void> {
   acting.value = true

--- a/frontend/components/user/UserProfileTabs.vue
+++ b/frontend/components/user/UserProfileTabs.vue
@@ -1,0 +1,80 @@
+<script setup lang="ts">
+const props = defineProps<{
+  username: string
+  isOwnProfile?: boolean
+}>()
+
+const route = useRoute()
+
+interface TabItem {
+  label: string
+  to: string
+  icon: string
+  ownOnly?: boolean
+}
+
+const tabs = computed<TabItem[]>(() => {
+  const base = `/@${props.username}`
+  const items: TabItem[] = [
+    { label: 'Overview', to: base, icon: 'overview' },
+    { label: 'Posts', to: `${base}/posts`, icon: 'posts' },
+    { label: 'Comments', to: `${base}/comments`, icon: 'comments' },
+  ]
+
+  if (props.isOwnProfile) {
+    items.push(
+      { label: 'Saved', to: `${base}/saved`, icon: 'saved', ownOnly: true },
+      { label: 'Following', to: `${base}/following`, icon: 'following', ownOnly: true },
+    )
+  }
+
+  return items
+})
+
+function isActive (tab: TabItem): boolean {
+  if (tab.to === `/@${props.username}`) {
+    return route.path === tab.to || route.path === `${tab.to}/`
+  }
+  return route.path.startsWith(tab.to)
+}
+</script>
+
+<template>
+  <nav class="bg-white border-b border-gray-200">
+    <div class="max-w-5xl mx-auto px-4 flex gap-0.5 overflow-x-auto scrollbar-hidden">
+      <NuxtLink
+        v-for="tab in tabs"
+        :key="tab.to"
+        :to="tab.to"
+        class="px-3 py-2.5 text-sm whitespace-nowrap no-underline transition-colors border-b-2 flex items-center gap-1.5"
+        :class="[
+          isActive(tab)
+            ? 'border-primary text-primary font-medium'
+            : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+        ]"
+      >
+        <!-- Overview icon -->
+        <svg v-if="tab.icon === 'overview'" class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+        </svg>
+        <!-- Posts icon -->
+        <svg v-if="tab.icon === 'posts'" class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 20H5a2 2 0 01-2-2V6a2 2 0 012-2h10a2 2 0 012 2v1m2 13a2 2 0 01-2-2V7m2 13a2 2 0 002-2V9a2 2 0 00-2-2h-2m-4-3H9M7 16h6M7 8h6v4H7V8z" />
+        </svg>
+        <!-- Comments icon -->
+        <svg v-if="tab.icon === 'comments'" class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z" />
+        </svg>
+        <!-- Saved icon -->
+        <svg v-if="tab.icon === 'saved'" class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
+        </svg>
+        <!-- Following icon -->
+        <svg v-if="tab.icon === 'following'" class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z" />
+        </svg>
+        {{ tab.label }}
+      </NuxtLink>
+    </div>
+  </nav>
+</template>

--- a/frontend/pages/@[username].vue
+++ b/frontend/pages/@[username].vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+import { useUser } from '~/composables/useUser'
+import { useAuthStore } from '~/stores/auth'
+
+const route = useRoute()
+const username = computed(() => route.params.username as string)
+const authStore = useAuthStore()
+
+const { user, loading, error, fetchUser } = useUser()
+
+const isOwnProfile = computed(() => authStore.user?.name === username.value)
+
+useHead({ title: computed(() => user.value?.displayName ?? username.value) })
+useSeoMeta({
+  title: computed(() => `${user.value?.displayName ?? username.value} (@${username.value})`),
+  ogTitle: computed(() => `${user.value?.displayName ?? username.value} (@${username.value})`),
+  description: computed(() => user.value?.bio ? user.value.bio.substring(0, 160) : `Profile of @${username.value}`),
+  ogDescription: computed(() => user.value?.bio ? user.value.bio.substring(0, 160) : `Profile of @${username.value}`),
+  ogImage: computed(() => user.value?.avatar || undefined),
+  ogType: 'profile',
+})
+
+watch(username, (name) => { fetchUser(name) })
+await fetchUser(username.value)
+
+// Provide user data to child pages
+provide('profileUser', user)
+provide('profileLoading', loading)
+provide('profileIsOwnProfile', isOwnProfile)
+</script>
+
+<template>
+  <div>
+    <CommonLoadingSpinner v-if="loading && !user" size="lg" />
+    <CommonErrorDisplay v-else-if="error" :message="error.message" @retry="fetchUser(username)" />
+
+    <template v-else-if="user">
+      <UserProfile :user="user" :is-own-profile="isOwnProfile" />
+      <UserProfileTabs :username="username" :is-own-profile="isOwnProfile" />
+
+      <div class="max-w-5xl mx-auto px-4 py-4">
+        <UserActions v-if="!isOwnProfile" :user="user" class="mb-4" />
+        <NuxtPage />
+      </div>
+    </template>
+  </div>
+</template>

--- a/frontend/pages/@[username]/comments.vue
+++ b/frontend/pages/@[username]/comments.vue
@@ -5,8 +5,6 @@ import type { Comment } from '~/types/generated'
 const route = useRoute()
 const username = computed(() => route.params.username as string)
 
-useHead({ title: computed(() => `Comments - @${username.value}`) })
-
 const USER_COMMENTS_QUERY = `
   query UserComments($userName: String, $sort: CommentSortType, $page: Int, $limit: Int) {
     comments(userName: $userName, sort: $sort, page: $page, limit: $limit) {
@@ -75,7 +73,7 @@ await fetchComments()
 </script>
 
 <template>
-  <div class="max-w-5xl mx-auto px-4 py-4">
+  <div>
     <div class="bg-white rounded-lg border border-gray-200 px-3 py-2 flex items-center justify-between mb-4">
       <h2 class="text-sm font-semibold text-gray-900">
         Comments by @{{ username }}

--- a/frontend/pages/@[username]/following.vue
+++ b/frontend/pages/@[username]/following.vue
@@ -1,0 +1,103 @@
+<script setup lang="ts">
+import { useAuthStore } from '~/stores/auth'
+import { useGraphQL } from '~/composables/useGraphQL'
+import type { User } from '~/types/generated'
+
+definePageMeta({ middleware: 'guards' })
+
+const route = useRoute()
+const username = computed(() => route.params.username as string)
+const authStore = useAuthStore()
+const profileUser = inject<Ref<User | null>>('profileUser')
+
+const isOwnProfile = computed(() => authStore.user?.name === username.value)
+
+const FOLLOWING_QUERY = `
+  query UserFollowing($userId: ID!) {
+    userFollowing(userId: $userId) {
+      id
+      name
+      displayName
+      avatar
+      bio
+      postCount
+      commentCount
+      createdAt
+    }
+  }
+`
+
+interface FollowingResponse {
+  userFollowing: User[]
+}
+
+const { execute, loading, error } = useGraphQL<FollowingResponse>()
+const following = ref<User[]>([])
+
+async function fetchFollowing (): Promise<void> {
+  const userId = profileUser?.value?.id
+  if (!userId) return
+  const result = await execute(FOLLOWING_QUERY, {
+    variables: { userId },
+  })
+  following.value = result?.userFollowing ?? []
+}
+
+if (isOwnProfile.value && profileUser?.value?.id) {
+  await fetchFollowing()
+}
+</script>
+
+<template>
+  <div>
+    <template v-if="isOwnProfile">
+      <div class="bg-white rounded-lg border border-gray-200 px-4 py-2.5 mb-4">
+        <h2 class="text-sm font-semibold text-gray-900">Following</h2>
+      </div>
+
+      <CommonErrorDisplay v-if="error" :message="error.message" @retry="fetchFollowing" />
+      <CommonLoadingSpinner v-else-if="loading" size="lg" />
+
+      <div v-else-if="following.length > 0" class="space-y-2">
+        <NuxtLink
+          v-for="user in following"
+          :key="user.id"
+          :to="`/@${user.name}`"
+          class="flex items-center gap-3 bg-white border border-gray-200 rounded-lg p-3 hover:border-gray-300 transition-colors no-underline"
+        >
+          <CommonAvatar
+            :src="user.avatar ?? undefined"
+            :name="user.name"
+            size="md"
+          />
+          <div class="flex-1 min-w-0">
+            <p class="text-sm font-medium text-gray-900 truncate">
+              {{ user.displayName ?? user.name }}
+            </p>
+            <p class="text-xs text-gray-500">@{{ user.name }}</p>
+            <p v-if="user.bio" class="text-xs text-gray-400 truncate mt-0.5">{{ user.bio }}</p>
+          </div>
+          <div class="text-right text-xs text-gray-400 shrink-0">
+            <span>{{ user.postCount ?? 0 }} posts</span>
+          </div>
+        </NuxtLink>
+      </div>
+
+      <div v-else class="bg-white rounded-lg border border-gray-200 py-12 text-center">
+        <div class="inline-flex w-12 h-12 rounded-xl bg-gray-100 items-center justify-center mb-3">
+          <svg class="w-6 h-6 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z" />
+          </svg>
+        </div>
+        <p class="text-sm font-medium text-gray-600 mb-1">Not following anyone yet</p>
+        <p class="text-xs text-gray-400">Follow users to see their content on your home feed.</p>
+      </div>
+    </template>
+    <CommonErrorDisplay
+      v-else
+      title="Not available"
+      message="You can only view your own following list."
+      :retryable="false"
+    />
+  </div>
+</template>

--- a/frontend/pages/@[username]/index.vue
+++ b/frontend/pages/@[username]/index.vue
@@ -1,26 +1,9 @@
 <script setup lang="ts">
-import { useUser } from '~/composables/useUser'
-import { useAuthStore } from '~/stores/auth'
 import { useGraphQL } from '~/composables/useGraphQL'
-import type { Post } from '~/types/generated'
+import type { Post, Comment } from '~/types/generated'
 
 const route = useRoute()
 const username = computed(() => route.params.username as string)
-const authStore = useAuthStore()
-
-const { user, loading, error, fetchUser } = useUser()
-
-useHead({ title: computed(() => user.value?.displayName ?? username.value) })
-useSeoMeta({
-  title: computed(() => `${user.value?.displayName ?? username.value} (@${username.value})`),
-  ogTitle: computed(() => `${user.value?.displayName ?? username.value} (@${username.value})`),
-  description: computed(() => user.value?.bio ? user.value.bio.substring(0, 160) : `Profile of @${username.value}`),
-  ogDescription: computed(() => user.value?.bio ? user.value.bio.substring(0, 160) : `Profile of @${username.value}`),
-  ogImage: computed(() => user.value?.avatar || undefined),
-  ogType: 'profile',
-})
-
-const isOwnProfile = computed(() => authStore.user?.name === username.value)
 
 const RECENT_POSTS_QUERY = `
   query RecentPosts($userName: String, $limit: Int) {
@@ -33,51 +16,123 @@ const RECENT_POSTS_QUERY = `
       slug
       score
       commentCount
+      myVote
       board { id name title icon }
       creator { id name displayName avatar }
     }
   }
 `
 
-interface RecentPostsResponse {
-  listPosts: Post[]
-}
+const RECENT_COMMENTS_QUERY = `
+  query RecentComments($userName: String, $limit: Int) {
+    comments(userName: $userName, limit: $limit) {
+      id
+      body
+      createdAt
+      score
+      upvotes
+      downvotes
+      replyCount
+      postId
+      boardId
+      creator { id name displayName avatar }
+    }
+  }
+`
+
+interface RecentPostsResponse { listPosts: Post[] }
+interface RecentCommentsResponse { comments: Comment[] }
 
 const { execute: execPosts, loading: postsLoading } = useGraphQL<RecentPostsResponse>()
+const { execute: execComments, loading: commentsLoading } = useGraphQL<RecentCommentsResponse>()
 const recentPosts = ref<Post[]>([])
+const recentComments = ref<Comment[]>([])
 
-async function loadProfile (name: string): Promise<void> {
-  await fetchUser(name)
-  if (user.value) {
-    const postsResult = await execPosts(RECENT_POSTS_QUERY, {
-      variables: { userName: name, limit: 10 },
-    })
-    recentPosts.value = postsResult?.listPosts ?? []
-  }
+const activeTab = ref<'overview' | 'posts' | 'comments'>('overview')
+
+async function loadContent (name: string): Promise<void> {
+  const [postsResult, commentsResult] = await Promise.all([
+    execPosts(RECENT_POSTS_QUERY, { variables: { userName: name, limit: 10 } }),
+    execComments(RECENT_COMMENTS_QUERY, { variables: { userName: name, limit: 10 } }),
+  ])
+  recentPosts.value = postsResult?.listPosts ?? []
+  recentComments.value = commentsResult?.comments ?? []
 }
 
-watch(username, (name) => { loadProfile(name) })
-await loadProfile(username.value)
+watch(username, (name) => { loadContent(name) })
+await loadContent(username.value)
 </script>
 
 <template>
   <div>
-    <CommonLoadingSpinner v-if="loading && !user" size="lg" />
-    <CommonErrorDisplay v-else-if="error" :message="error.message" @retry="loadProfile(username)" />
+    <!-- Content type filter for overview -->
+    <div class="flex gap-1 mb-4">
+      <button
+        class="px-3 py-1.5 text-xs font-medium rounded-full transition-colors"
+        :class="activeTab === 'overview' ? 'bg-primary text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'"
+        @click="activeTab = 'overview'"
+      >
+        All
+      </button>
+      <button
+        class="px-3 py-1.5 text-xs font-medium rounded-full transition-colors"
+        :class="activeTab === 'posts' ? 'bg-primary text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'"
+        @click="activeTab = 'posts'"
+      >
+        Posts
+      </button>
+      <button
+        class="px-3 py-1.5 text-xs font-medium rounded-full transition-colors"
+        :class="activeTab === 'comments' ? 'bg-primary text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'"
+        @click="activeTab = 'comments'"
+      >
+        Comments
+      </button>
+    </div>
 
-    <template v-else-if="user">
-      <UserProfile :user="user" :is-own-profile="isOwnProfile" />
-
-      <div class="max-w-5xl mx-auto px-4 py-4">
-        <UserActions v-if="!isOwnProfile" :user="user" class="mb-4" />
-
-        <div class="bg-white rounded-lg border border-gray-200 px-4 py-3 mb-4">
+    <!-- Posts section -->
+    <template v-if="activeTab === 'overview' || activeTab === 'posts'">
+      <div v-if="activeTab === 'overview'" class="bg-white rounded-lg border border-gray-200 px-4 py-2.5 mb-3">
+        <div class="flex items-center justify-between">
           <h3 class="text-sm font-semibold text-gray-700">Recent Posts</h3>
+          <NuxtLink :to="`/@${username}/posts`" class="text-xs text-primary hover:text-primary-hover no-underline">
+            View all
+          </NuxtLink>
         </div>
-        <PostList :posts="recentPosts" :loading="postsLoading" />
-        <div v-if="!postsLoading && recentPosts.length === 0" class="bg-white rounded-lg border border-gray-200 py-12 text-center">
-          <p class="text-sm text-gray-500">No posts yet.</p>
+      </div>
+      <PostList :posts="recentPosts" :loading="postsLoading" />
+      <div v-if="!postsLoading && recentPosts.length === 0" class="bg-white rounded-lg border border-gray-200 py-8 text-center mb-4">
+        <p class="text-sm text-gray-500">No posts yet.</p>
+      </div>
+    </template>
+
+    <!-- Comments section -->
+    <template v-if="activeTab === 'overview' || activeTab === 'comments'">
+      <div v-if="activeTab === 'overview'" class="bg-white rounded-lg border border-gray-200 px-4 py-2.5 mb-3 mt-4">
+        <div class="flex items-center justify-between">
+          <h3 class="text-sm font-semibold text-gray-700">Recent Comments</h3>
+          <NuxtLink :to="`/@${username}/comments`" class="text-xs text-primary hover:text-primary-hover no-underline">
+            View all
+          </NuxtLink>
         </div>
+      </div>
+      <CommonLoadingSpinner v-if="commentsLoading && recentComments.length === 0" size="md" />
+      <div v-else-if="recentComments.length > 0" class="space-y-2">
+        <div
+          v-for="comment in recentComments"
+          :key="comment.id"
+          class="bg-white border border-gray-200 rounded-lg p-3"
+        >
+          <div class="flex items-center gap-2 text-xs text-gray-500 mb-1">
+            <span>{{ comment.score }} points</span>
+            <span>&middot;</span>
+            <span>{{ comment.createdAt }}</span>
+          </div>
+          <p class="text-sm text-gray-800 line-clamp-3">{{ comment.body }}</p>
+        </div>
+      </div>
+      <div v-else-if="!commentsLoading" class="bg-white rounded-lg border border-gray-200 py-8 text-center">
+        <p class="text-sm text-gray-500">No comments yet.</p>
       </div>
     </template>
   </div>

--- a/frontend/pages/@[username]/posts.vue
+++ b/frontend/pages/@[username]/posts.vue
@@ -3,9 +3,7 @@ import { useGraphQL } from '~/composables/useGraphQL'
 import type { Post } from '~/types/generated'
 
 const route = useRoute()
-const username = (route.params.username as string)
-
-useHead({ title: `Posts - @${username}` })
+const username = computed(() => route.params.username as string)
 
 const USER_POSTS_QUERY = `
   query UserPosts($userName: String, $sort: SortType, $page: Int, $limit: Int) {
@@ -46,7 +44,7 @@ const hasMore = ref(false)
 
 async function fetchPosts (): Promise<void> {
   const result = await execute(USER_POSTS_QUERY, {
-    variables: { userName: username, sort: sort.value, page: page.value, limit: limit + 1 },
+    variables: { userName: username.value, sort: sort.value, page: page.value, limit: limit + 1 },
   })
   if (result?.listPosts) {
     hasMore.value = result.listPosts.length > limit
@@ -68,11 +66,15 @@ async function prevPage (): Promise<void> {
   if (page.value > 1) { page.value--; await fetchPosts() }
 }
 
+watch(username, () => {
+  page.value = 1
+  fetchPosts()
+})
 await fetchPosts()
 </script>
 
 <template>
-  <div class="max-w-5xl mx-auto px-4 py-4">
+  <div>
     <div class="bg-white rounded-lg border border-gray-200 px-3 py-2 flex items-center justify-between mb-4">
       <h2 class="text-sm font-semibold text-gray-900">
         Posts by @{{ username }}

--- a/frontend/pages/@[username]/saved.vue
+++ b/frontend/pages/@[username]/saved.vue
@@ -9,13 +9,11 @@ const route = useRoute()
 const username = computed(() => route.params.username as string)
 const authStore = useAuthStore()
 
-useHead({ title: computed(() => `Saved - @${username.value}`) })
-
 const isOwnProfile = computed(() => authStore.user?.name === username.value)
 
 const SAVED_POSTS_QUERY = `
-  query SavedPosts($savedOnly: Boolean, $page: Int, $limit: Int) {
-    listPosts(savedOnly: $savedOnly, page: $page, limit: $limit) {
+  query SavedPosts($savedOnly: Boolean, $sort: SortType, $page: Int, $limit: Int) {
+    listPosts(savedOnly: $savedOnly, sort: $sort, page: $page, limit: $limit) {
       id
       title
       body
@@ -46,17 +44,24 @@ interface SavedPostsResponse {
 const { execute, loading, error } = useGraphQL<SavedPostsResponse>()
 const posts = ref<Post[]>([])
 const page = ref(1)
+const sort = ref('new')
 const limit = 25
 const hasMore = ref(false)
 
 async function fetchSaved (): Promise<void> {
   const result = await execute(SAVED_POSTS_QUERY, {
-    variables: { savedOnly: true, page: page.value, limit: limit + 1 },
+    variables: { savedOnly: true, sort: sort.value, page: page.value, limit: limit + 1 },
   })
   if (result?.listPosts) {
     hasMore.value = result.listPosts.length > limit
     posts.value = result.listPosts.slice(0, limit)
   }
+}
+
+async function setSort (newSort: string): Promise<void> {
+  sort.value = newSort
+  page.value = 1
+  await fetchSaved()
 }
 
 async function nextPage (): Promise<void> {
@@ -73,12 +78,13 @@ if (isOwnProfile.value) {
 </script>
 
 <template>
-  <div class="max-w-5xl mx-auto px-4 py-4">
+  <div>
     <template v-if="isOwnProfile">
-      <div class="bg-white rounded-lg border border-gray-200 px-4 py-3 mb-4">
-        <h2 class="text-base font-semibold text-gray-900">
-          Saved
+      <div class="bg-white rounded-lg border border-gray-200 px-3 py-2 flex items-center justify-between mb-4">
+        <h2 class="text-sm font-semibold text-gray-900">
+          Saved Posts
         </h2>
+        <CommonSortSelector v-model="sort" @update:model-value="setSort" />
       </div>
 
       <CommonErrorDisplay v-if="error" :message="error.message" @retry="fetchSaved" />
@@ -92,9 +98,15 @@ if (isOwnProfile.value) {
         @next="nextPage"
       />
 
-      <p v-if="!loading && posts.length === 0" class="text-sm text-gray-500 text-center py-8">
-        No saved posts yet.
-      </p>
+      <div v-if="!loading && posts.length === 0" class="bg-white rounded-lg border border-gray-200 py-12 text-center">
+        <div class="inline-flex w-12 h-12 rounded-xl bg-gray-100 items-center justify-center mb-3">
+          <svg class="w-6 h-6 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
+          </svg>
+        </div>
+        <p class="text-sm font-medium text-gray-600 mb-1">No saved posts yet</p>
+        <p class="text-xs text-gray-400">Click the save button on any post to bookmark it here.</p>
+      </div>
     </template>
     <CommonErrorDisplay
       v-else

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -14,6 +14,9 @@ type Query {
   user(username: String!): User!
   listUsers(searchTerm: String, page: Int, limit: Int): [User!]!
   searchUsernames(query: String!, limit: Int): [String!]!
+  userFollowers(userId: ID!): [User!]!
+  userFollowing(userId: ID!): [User!]!
+  isFollowingUser(userId: ID!): Boolean!
 
   # Boards
   board(name: String!): Board!

--- a/schema.graphql
+++ b/schema.graphql
@@ -14,6 +14,9 @@ type Query {
   user(username: String!): User!
   listUsers(searchTerm: String, page: Int, limit: Int): [User!]!
   searchUsernames(query: String!, limit: Int): [String!]!
+  userFollowers(userId: ID!): [User!]!
+  userFollowing(userId: ID!): [User!]!
+  isFollowingUser(userId: ID!): Boolean!
 
   # Boards
   board(name: String!): Board!


### PR DESCRIPTION
…ing pages

Restructure user profile pages using Nuxt nested routing with a parent layout that renders the profile header and tab bar on all sub-pages.

- Add UserProfileTabs component with Overview, Posts, Comments, Saved, and Following tabs (Saved/Following only visible on own profile)
- Create parent @[username].vue layout with shared UserProfile header, tabs, and UserActions
- Refactor Overview tab to show both recent posts and comments with content type filter pills (All/Posts/Comments)
- Add Following page showing users the current user follows
- Enhance Saved page with sort controls and descriptive empty states
- Update UserActions to fetch initial follow state via isFollowingUser query on mount
- Add userFollowers, userFollowing, isFollowingUser queries to both frontend and root GraphQL schemas