### PR TITLE
feat(ui): revamp post/comment actions with unified mod menu and toast…

### DIFF
--- a/frontend/components/comment/CommentActions.vue
+++ b/frontend/components/comment/CommentActions.vue
@@ -5,6 +5,7 @@ import { useGraphQL } from '~/composables/useGraphQL'
 import { useModeration } from '~/composables/useModeration'
 import { useAuthStore } from '~/stores/auth'
 import { useSiteStore } from '~/stores/site'
+import { useToast } from '~/composables/useToast'
 
 const props = defineProps<{
   comment: Comment
@@ -18,6 +19,7 @@ const emit = defineEmits<{
 
 const authStore = useAuthStore()
 const siteStore = useSiteStore()
+const toast = useToast()
 const { removeComment, restoreComment } = useModeration()
 
 // Local reactive state so vote updates are immediately visible
@@ -29,6 +31,7 @@ watch(() => props.comment.myVote, (v) => { localMyVote.value = v ?? 0 })
 
 const showRemoveDialog = ref(false)
 const showReportDialog = ref(false)
+const showModMenu = ref(false)
 const removeReason = ref('')
 const reportReason = ref('')
 const acting = ref(false)
@@ -36,11 +39,7 @@ const acting = ref(false)
 const VOTE_MUTATION = `
   mutation VoteOnComment($commentId: ID!, $direction: Int!) {
     voteOnComment(commentId: $commentId, direction: $direction) {
-      id
-      score
-      upvotes
-      downvotes
-      myVote
+      id score upvotes downvotes myVote
     }
   }
 `
@@ -57,12 +56,20 @@ const PIN_MUTATION = `
   }
 `
 
+const SAVE_COMMENT_MUTATION = `
+  mutation SaveComment($commentId: ID!) { saveComment(commentId: $commentId) { id isSaved } }
+`
+const UNSAVE_COMMENT_MUTATION = `
+  mutation UnsaveComment($commentId: ID!) { unsaveComment(commentId: $commentId) { id isSaved } }
+`
+
 interface VoteResponse {
   voteOnComment: { id: string; score: number; upvotes: number; downvotes: number; myVote: number }
 }
 
 const canModerate = computed(() => props.isModerator || authStore.isAdmin)
 const isOwnComment = computed(() => authStore.user?.id === props.comment.creator?.id)
+const commentSaved = ref(props.comment.isSaved ?? false)
 
 async function vote (score: number): Promise<void> {
   if (!authStore.isLoggedIn) {
@@ -87,6 +94,16 @@ async function vote (score: number): Promise<void> {
   }
 }
 
+async function toggleSaveComment (): Promise<void> {
+  const { execute } = useGraphQL()
+  const mutation = commentSaved.value ? UNSAVE_COMMENT_MUTATION : SAVE_COMMENT_MUTATION
+  const result = await execute(mutation, { variables: { commentId: props.comment.id } })
+  if (result) {
+    commentSaved.value = !commentSaved.value
+    toast.success(commentSaved.value ? 'Comment saved' : 'Comment unsaved')
+  }
+}
+
 async function handleRemove (): Promise<void> {
   acting.value = true
   const success = await removeComment(props.comment.id, removeReason.value || undefined)
@@ -98,6 +115,7 @@ async function handleRemove (): Promise<void> {
 
 async function handleRestore (): Promise<void> {
   acting.value = true
+  showModMenu.value = false
   const success = await restoreComment(props.comment.id)
   acting.value = false
   if (success) emit('updated')
@@ -106,84 +124,174 @@ async function handleRestore (): Promise<void> {
 async function submitReport (): Promise<void> {
   if (!reportReason.value.trim()) return
   const { execute } = useGraphQL()
-  await execute(REPORT_MUTATION, { variables: { commentId: props.comment.id, reason: reportReason.value } })
+  const result = await execute(REPORT_MUTATION, { variables: { commentId: props.comment.id, reason: reportReason.value } })
   showReportDialog.value = false
   reportReason.value = ''
+  if (result) toast.success('Report submitted')
 }
 
 async function togglePin (): Promise<void> {
   acting.value = true
+  showModMenu.value = false
   const { execute } = useGraphQL()
-  await execute(PIN_MUTATION, { variables: { commentId: props.comment.id } })
+  const result = await execute(PIN_MUTATION, { variables: { commentId: props.comment.id } })
   acting.value = false
-  emit('updated')
+  if (result) {
+    toast.success(props.comment.isPinned ? 'Comment unpinned' : 'Comment pinned')
+    emit('updated')
+  }
+}
+
+function openRemoveDialog (): void {
+  showModMenu.value = false
+  showRemoveDialog.value = true
 }
 </script>
 
 <template>
-  <div class="flex items-center gap-2 mt-1 text-xs text-gray-400 flex-wrap">
+  <div class="flex items-center gap-1 mt-1.5 text-xs text-gray-400 flex-wrap">
+    <!-- Upvote -->
     <button
-      class="hover:text-gray-600"
-      :class="{ 'text-primary': localMyVote === 1 }"
+      class="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded hover:bg-primary/10 transition-colors"
+      :class="localMyVote === 1 ? 'text-primary' : 'hover:text-primary'"
       @click="vote(1)"
     >
-      upvote
+      <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7" />
+      </svg>
     </button>
-    <span class="font-medium" :class="localMyVote === 1 ? 'text-primary' : localMyVote === -1 ? 'text-secondary' : 'text-gray-500'">
+
+    <!-- Score -->
+    <span
+      class="font-semibold text-xs min-w-[2ch] text-center tabular-nums select-none"
+      :class="localMyVote === 1 ? 'text-primary' : localMyVote === -1 ? 'text-secondary' : 'text-gray-500'"
+    >
       {{ localScore }}
     </span>
+
+    <!-- Downvote -->
     <button
       v-if="siteStore.enableDownvotes"
-      class="hover:text-gray-600"
-      :class="{ 'text-secondary': localMyVote === -1 }"
+      class="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded hover:bg-secondary/10 transition-colors"
+      :class="localMyVote === -1 ? 'text-secondary' : 'hover:text-secondary'"
       @click="vote(-1)"
     >
-      downvote
+      <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+      </svg>
     </button>
+
+    <span class="text-gray-200 mx-0.5">|</span>
+
+    <!-- Reply -->
     <button
       v-if="authStore.isLoggedIn"
-      class="hover:text-gray-600"
+      class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded hover:bg-gray-100 hover:text-gray-600 transition-colors"
       @click="emit('toggle-reply')"
     >
-      reply
+      <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6" />
+      </svg>
+      Reply
+    </button>
+
+    <!-- Save -->
+    <button
+      v-if="authStore.isLoggedIn"
+      class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded transition-colors"
+      :class="commentSaved ? 'text-primary hover:bg-primary/10' : 'hover:bg-gray-100 hover:text-gray-600'"
+      @click="toggleSaveComment"
+    >
+      <svg class="w-3.5 h-3.5" :fill="commentSaved ? 'currentColor' : 'none'" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
+      </svg>
+      {{ commentSaved ? 'Saved' : 'Save' }}
     </button>
 
     <!-- Report (non-own comments) -->
     <button
       v-if="authStore.isLoggedIn && !isOwnComment"
-      class="hover:text-red-500"
+      class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded hover:bg-gray-100 hover:text-red-500 transition-colors"
       @click="showReportDialog = true"
     >
-      report
+      <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 21v-4m0 0V5a2 2 0 012-2h6.5l1 1H21l-3 6 3 6h-8.5l-1-1H5a2 2 0 00-2 2zm9-13.5V9" />
+      </svg>
+      Report
     </button>
 
-    <!-- Mod actions -->
+    <!-- Mod actions menu -->
     <template v-if="canModerate">
-      <span class="text-gray-200">|</span>
-      <button
-        class="hover:text-amber-500"
-        :class="{ 'text-amber-500': comment.isPinned }"
-        :disabled="acting"
-        @click="togglePin"
-      >
-        {{ comment.isPinned ? 'unpin' : 'pin' }}
-      </button>
-      <button
-        v-if="!comment.isRemoved"
-        class="hover:text-red-500"
-        :disabled="acting"
-        @click="showRemoveDialog = true"
-      >
-        remove
-      </button>
-      <button
-        v-else
-        class="text-red-400 hover:text-green-500"
-        :disabled="acting"
-        @click="handleRestore"
-      >
-        restore
-      </button>
+      <span class="text-gray-200 mx-0.5">|</span>
+      <div class="relative">
+        <button
+          class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded transition-colors"
+          :class="showModMenu ? 'bg-gray-100 text-gray-700' : 'hover:bg-gray-100 hover:text-gray-600'"
+          @click="showModMenu = !showModMenu"
+        >
+          <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+          </svg>
+          Mod
+        </button>
+
+        <!-- Dropdown -->
+        <Teleport to="body">
+          <div
+            v-if="showModMenu"
+            class="fixed inset-0 z-40"
+            @click="showModMenu = false"
+          />
+        </Teleport>
+        <div
+          v-if="showModMenu"
+          class="absolute left-0 top-full mt-1 w-44 bg-white rounded-lg border border-gray-200 shadow-lg z-50 py-1"
+        >
+          <div class="px-3 py-1.5 text-[10px] font-semibold text-gray-400 uppercase tracking-wider">
+            Moderation
+          </div>
+
+          <!-- Pin/Unpin -->
+          <button
+            class="w-full flex items-center gap-2 px-3 py-2 text-sm transition-colors"
+            :class="comment.isPinned ? 'text-amber-700 hover:bg-amber-50' : 'text-gray-700 hover:bg-gray-50'"
+            :disabled="acting"
+            @click="togglePin"
+          >
+            <svg class="w-4 h-4" :class="comment.isPinned ? 'text-amber-500' : 'text-gray-400'" fill="currentColor" viewBox="0 0 20 20">
+              <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+            </svg>
+            {{ comment.isPinned ? 'Unpin' : 'Pin' }}
+          </button>
+
+          <div class="border-t border-gray-100 my-1" />
+
+          <!-- Remove/Restore -->
+          <button
+            v-if="!comment.isRemoved"
+            class="w-full flex items-center gap-2 px-3 py-2 text-sm text-red-600 hover:bg-red-50 transition-colors"
+            :disabled="acting"
+            @click="openRemoveDialog"
+          >
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" />
+            </svg>
+            Remove
+          </button>
+          <button
+            v-else
+            class="w-full flex items-center gap-2 px-3 py-2 text-sm text-green-600 hover:bg-green-50 transition-colors"
+            :disabled="acting"
+            @click="handleRestore"
+          >
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+            </svg>
+            Restore
+          </button>
+        </div>
+      </div>
     </template>
 
     <!-- Remove dialog -->

--- a/frontend/components/post/PostCard.vue
+++ b/frontend/components/post/PostCard.vue
@@ -1,13 +1,40 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import type { Post } from '~/types/generated'
 import { timeAgo } from '~/utils/date'
 import { postUrl } from '~/utils/slug'
+import { useGraphQL } from '~/composables/useGraphQL'
+import { useAuthStore } from '~/stores/auth'
+import { useToast } from '~/composables/useToast'
 
 const props = defineProps<{
   post: Post
   compact?: boolean
 }>()
+
+const authStore = useAuthStore()
+const toast = useToast()
+
+const saved = ref(props.post.isSaved ?? false)
+const savePending = ref(false)
+
+watch(() => props.post.isSaved, (v) => { saved.value = v ?? false })
+
+const SAVE_MUTATION = `mutation SavePost($postId: ID!) { savePost(postId: $postId) { id isSaved } }`
+const UNSAVE_MUTATION = `mutation UnsavePost($postId: ID!) { unsavePost(postId: $postId) { id isSaved } }`
+
+async function toggleSave (): Promise<void> {
+  if (!authStore.isLoggedIn) { navigateTo('/login'); return }
+  savePending.value = true
+  const { execute } = useGraphQL()
+  const mutation = saved.value ? UNSAVE_MUTATION : SAVE_MUTATION
+  const result = await execute(mutation, { variables: { postId: props.post.id } })
+  if (result) {
+    saved.value = !saved.value
+    toast.success(saved.value ? 'Post saved' : 'Post unsaved')
+  }
+  savePending.value = false
+}
 
 const isThread = computed(() => props.post.isThread)
 
@@ -292,11 +319,16 @@ const hasLinkPreview = computed(() => {
               {{ post.commentCount }} {{ post.commentCount === 1 ? 'Comment' : 'Comments' }}
             </NuxtLink>
 
-            <button class="inline-flex items-center gap-1 text-gray-500 hover:text-gray-700 transition-colors">
-              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <button
+              class="inline-flex items-center gap-1 transition-colors"
+              :class="saved ? 'text-primary font-medium' : 'text-gray-500 hover:text-gray-700'"
+              :disabled="savePending"
+              @click="toggleSave"
+            >
+              <svg class="w-3.5 h-3.5" :fill="saved ? 'currentColor' : 'none'" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
               </svg>
-              Save
+              {{ saved ? 'Saved' : 'Save' }}
             </button>
 
             <!-- Board name (shown in combined feed views) -->

--- a/frontend/components/post/PostDetail.vue
+++ b/frontend/components/post/PostDetail.vue
@@ -5,6 +5,7 @@ import { sanitizeHtml } from '~/utils/sanitize'
 import { useAuthStore } from '~/stores/auth'
 import { useGraphQL } from '~/composables/useGraphQL'
 import { useModeration } from '~/composables/useModeration'
+import { useToast } from '~/composables/useToast'
 
 const props = defineProps<{
   post: Post
@@ -17,26 +18,23 @@ const emit = defineEmits<{
 }>()
 
 const authStore = useAuthStore()
+const toast = useToast()
 
-const { removePost: doRemovePost } = useModeration()
+const { removePost: doRemovePost, restorePost: doRestorePost, lockPost: doLockPost, unlockPost: doUnlockPost, featurePost: doFeaturePost } = useModeration()
 
-const SAVE_MUTATION = `
-  mutation SavePost($postId: ID!) { savePost(postId: $postId) { id isSaved } }
-`
-const UNSAVE_MUTATION = `
-  mutation UnsavePost($postId: ID!) { unsavePost(postId: $postId) { id isSaved } }
-`
-const DELETE_MUTATION = `
-  mutation DeletePost($postId: ID!) { deletePost(postId: $postId) { id } }
-`
-const REPORT_MUTATION = `
-  mutation ReportPost($postId: ID!, $reason: String!) { reportPost(postId: $postId, reason: $reason) { success } }
-`
+const SAVE_MUTATION = `mutation SavePost($postId: ID!) { savePost(postId: $postId) { id isSaved } }`
+const UNSAVE_MUTATION = `mutation UnsavePost($postId: ID!) { unsavePost(postId: $postId) { id isSaved } }`
+const DELETE_MUTATION = `mutation DeletePost($postId: ID!) { deletePost(postId: $postId) { id } }`
+const REPORT_MUTATION = `mutation ReportPost($postId: ID!, $reason: String!) { reportPost(postId: $postId, reason: $reason) { success } }`
 
 const saved = ref(props.post.isSaved ?? false)
 const showReport = ref(false)
 const reportReason = ref('')
 const showDeleteConfirm = ref(false)
+const showMoreMenu = ref(false)
+const showRemoveDialog = ref(false)
+const removeReason = ref('')
+const acting = ref(false)
 
 watch(() => props.post.isSaved, (v) => { saved.value = v ?? false })
 
@@ -47,22 +45,74 @@ async function toggleSave (): Promise<void> {
   const { execute } = useGraphQL()
   const mutation = saved.value ? UNSAVE_MUTATION : SAVE_MUTATION
   const result = await execute(mutation, { variables: { postId: props.post.id } })
-  if (result) saved.value = !saved.value
+  if (result) {
+    saved.value = !saved.value
+    toast.success(saved.value ? 'Post saved' : 'Post unsaved')
+  }
 }
 
 async function submitReport (): Promise<void> {
   if (!reportReason.value.trim()) return
   const { execute } = useGraphQL()
-  await execute(REPORT_MUTATION, { variables: { postId: props.post.id, reason: reportReason.value } })
+  const result = await execute(REPORT_MUTATION, { variables: { postId: props.post.id, reason: reportReason.value } })
   showReport.value = false
   reportReason.value = ''
+  if (result) toast.success('Report submitted')
 }
 
 async function deletePost (): Promise<void> {
   const { execute } = useGraphQL()
-  await execute(DELETE_MUTATION, { variables: { postId: props.post.id } })
+  const result = await execute(DELETE_MUTATION, { variables: { postId: props.post.id } })
   showDeleteConfirm.value = false
-  emit('deleted')
+  if (result) {
+    toast.success('Post deleted')
+    emit('deleted')
+  }
+}
+
+async function handleLockToggle (): Promise<void> {
+  acting.value = true
+  showMoreMenu.value = false
+  const success = props.post.isLocked
+    ? await doUnlockPost(props.post.id)
+    : await doLockPost(props.post.id)
+  acting.value = false
+  if (success) emit('post-updated')
+}
+
+async function handleFeatureToggle (): Promise<void> {
+  acting.value = true
+  showMoreMenu.value = false
+  const success = await doFeaturePost(props.post.id, !props.post.isFeaturedBoard, 'board')
+  acting.value = false
+  if (success) emit('post-updated')
+}
+
+async function handleRemove (): Promise<void> {
+  acting.value = true
+  const success = await doRemovePost(props.post.id, removeReason.value || undefined)
+  showRemoveDialog.value = false
+  removeReason.value = ''
+  acting.value = false
+  if (success) emit('post-updated')
+}
+
+async function handleRestore (): Promise<void> {
+  acting.value = true
+  showMoreMenu.value = false
+  const success = await doRestorePost(props.post.id)
+  acting.value = false
+  if (success) emit('post-updated')
+}
+
+function openRemoveDialog (): void {
+  showMoreMenu.value = false
+  showRemoveDialog.value = true
+}
+
+// Close menu on outside click
+function onClickOutsideMenu (e: Event): void {
+  showMoreMenu.value = false
 }
 </script>
 
@@ -123,12 +173,17 @@ async function deletePost (): Promise<void> {
           <time :datetime="post.createdAt">{{ timeAgo(post.createdAt) }}</time>
           <span v-if="post.isNSFW" class="badge badge-red ml-1">NSFW</span>
           <span v-if="post.isLocked" class="inline-flex items-center gap-0.5 text-yellow-500 ml-1">
-            <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+            <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20">
               <path fill-rule="evenodd" d="M5 9V7a5 5 0 0110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2zm8-2v2H7V7a3 3 0 016 0z" clip-rule="evenodd" />
             </svg>
             Locked
           </span>
-          <span v-if="post.isFeaturedBoard" class="text-green-500 ml-1">Pinned</span>
+          <span v-if="post.isFeaturedBoard" class="inline-flex items-center gap-0.5 text-green-500 ml-1">
+            <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20">
+              <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+            </svg>
+            Pinned
+          </span>
           <span v-if="post.isRemoved" class="text-red-500 ml-1">Removed</span>
         </div>
 
@@ -139,8 +194,9 @@ async function deletePost (): Promise<void> {
           {{ post.body }}
         </div>
 
-        <!-- User actions row -->
+        <!-- Action bar: unified user + mod actions -->
         <div class="flex items-center gap-1 mt-3 text-xs text-gray-500 flex-wrap">
+          <!-- Comments count -->
           <span class="inline-flex items-center gap-1">
             <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
@@ -148,24 +204,127 @@ async function deletePost (): Promise<void> {
             {{ post.commentCount }} comment{{ post.commentCount === 1 ? '' : 's' }}
           </span>
 
+          <!-- Save/Unsave -->
           <template v-if="authStore.isLoggedIn">
             <span class="text-gray-300">&middot;</span>
-            <button class="hover:text-gray-700" @click="toggleSave">
-              {{ saved ? 'Unsave' : 'Save' }}
+            <button
+              class="inline-flex items-center gap-1 transition-colors"
+              :class="saved ? 'text-primary font-medium' : 'hover:text-gray-700'"
+              @click="toggleSave"
+            >
+              <svg class="w-3.5 h-3.5" :fill="saved ? 'currentColor' : 'none'" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
+              </svg>
+              {{ saved ? 'Saved' : 'Save' }}
             </button>
 
+            <!-- Report (non-own) -->
             <template v-if="!isOwnPost">
               <span class="text-gray-300">&middot;</span>
-              <button class="hover:text-red-500" @click="showReport = true">
+              <button class="inline-flex items-center gap-1 hover:text-red-500 transition-colors" @click="showReport = true">
+                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 21v-4m0 0V5a2 2 0 012-2h6.5l1 1H21l-3 6 3 6h-8.5l-1-1H5a2 2 0 00-2 2zm9-13.5V9" />
+                </svg>
                 Report
               </button>
             </template>
 
+            <!-- Delete (own post) -->
             <template v-if="isOwnPost">
               <span class="text-gray-300">&middot;</span>
-              <button class="hover:text-red-500" @click="showDeleteConfirm = true">
+              <button class="inline-flex items-center gap-1 hover:text-red-500 transition-colors" @click="showDeleteConfirm = true">
+                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                </svg>
                 Delete
               </button>
+            </template>
+
+            <!-- Mod/Admin actions menu -->
+            <template v-if="canModerate">
+              <span class="text-gray-300">&middot;</span>
+              <div class="relative">
+                <button
+                  class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded hover:bg-gray-100 transition-colors"
+                  :class="showMoreMenu ? 'bg-gray-100 text-gray-700' : 'text-gray-500 hover:text-gray-700'"
+                  @click="showMoreMenu = !showMoreMenu"
+                >
+                  <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                  </svg>
+                  Mod
+                </button>
+
+                <!-- Dropdown menu -->
+                <Teleport to="body">
+                  <div
+                    v-if="showMoreMenu"
+                    class="fixed inset-0 z-40"
+                    @click="showMoreMenu = false"
+                  />
+                </Teleport>
+                <div
+                  v-if="showMoreMenu"
+                  class="absolute left-0 top-full mt-1 w-48 bg-white rounded-lg border border-gray-200 shadow-lg z-50 py-1"
+                >
+                  <div class="px-3 py-1.5 text-[10px] font-semibold text-gray-400 uppercase tracking-wider">
+                    Moderation
+                  </div>
+
+                  <!-- Lock/Unlock -->
+                  <button
+                    class="w-full flex items-center gap-2 px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                    :disabled="acting"
+                    @click="handleLockToggle"
+                  >
+                    <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path v-if="post.isLocked" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 11V7a4 4 0 118 0m-4 8v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2z" />
+                      <path v-else stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+                    </svg>
+                    {{ post.isLocked ? 'Unlock post' : 'Lock post' }}
+                  </button>
+
+                  <!-- Pin/Unpin -->
+                  <button
+                    class="w-full flex items-center gap-2 px-3 py-2 text-sm transition-colors"
+                    :class="post.isFeaturedBoard ? 'text-green-700 hover:bg-green-50' : 'text-gray-700 hover:bg-gray-50'"
+                    :disabled="acting"
+                    @click="handleFeatureToggle"
+                  >
+                    <svg class="w-4 h-4" :class="post.isFeaturedBoard ? 'text-green-500' : 'text-gray-400'" fill="currentColor" viewBox="0 0 20 20">
+                      <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+                    </svg>
+                    {{ post.isFeaturedBoard ? 'Unpin post' : 'Pin post' }}
+                  </button>
+
+                  <div class="border-t border-gray-100 my-1" />
+
+                  <!-- Remove/Restore -->
+                  <button
+                    v-if="!post.isRemoved"
+                    class="w-full flex items-center gap-2 px-3 py-2 text-sm text-red-600 hover:bg-red-50 transition-colors"
+                    :disabled="acting"
+                    @click="openRemoveDialog"
+                  >
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" />
+                    </svg>
+                    Remove post
+                  </button>
+                  <button
+                    v-else
+                    class="w-full flex items-center gap-2 px-3 py-2 text-sm text-green-600 hover:bg-green-50 transition-colors"
+                    :disabled="acting"
+                    @click="handleRestore"
+                  >
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                    </svg>
+                    Restore post
+                  </button>
+                </div>
+              </div>
             </template>
           </template>
         </div>
@@ -173,11 +332,6 @@ async function deletePost (): Promise<void> {
         <!-- Reactions (threads only) -->
         <div v-if="post.isThread" class="mt-3">
           <CommonReactionBar target-type="post" :target-id="post.id" />
-        </div>
-
-        <!-- Mod actions -->
-        <div v-if="canModerate" class="mt-2 pt-2 border-t border-gray-100">
-          <PostModActions :post="post" @updated="emit('post-updated')" />
         </div>
       </div>
     </div>
@@ -213,6 +367,31 @@ async function deletePost (): Promise<void> {
           <div class="flex gap-2 justify-end">
             <button class="button white button-sm" @click="showDeleteConfirm = false">Cancel</button>
             <button class="button button-sm bg-red-600 text-white hover:bg-red-700" @click="deletePost">Delete</button>
+          </div>
+        </div>
+      </template>
+    </CommonModal>
+
+    <!-- Remove reason dialog -->
+    <CommonModal v-if="showRemoveDialog" @close="showRemoveDialog = false">
+      <template #title>Remove Post</template>
+      <template #default>
+        <div class="space-y-3">
+          <p class="text-sm text-gray-600">Are you sure you want to remove this post?</p>
+          <div>
+            <label class="block text-sm font-medium text-gray-700 mb-1">Reason (optional)</label>
+            <input
+              v-model="removeReason"
+              type="text"
+              class="form-input"
+              placeholder="Reason for removal..."
+            />
+          </div>
+          <div class="flex gap-2 justify-end">
+            <button class="button white button-sm" @click="showRemoveDialog = false">Cancel</button>
+            <button class="button button-sm bg-red-600 text-white hover:bg-red-700" :disabled="acting" @click="handleRemove">
+              {{ acting ? 'Removing...' : 'Remove Post' }}
+            </button>
           </div>
         </div>
       </template>

--- a/frontend/components/thread/ThreadDetailHeader.vue
+++ b/frontend/components/thread/ThreadDetailHeader.vue
@@ -5,6 +5,7 @@ import { sanitizeHtml } from '~/utils/sanitize'
 import { useAuthStore } from '~/stores/auth'
 import { useGraphQL } from '~/composables/useGraphQL'
 import { useModeration } from '~/composables/useModeration'
+import { useToast } from '~/composables/useToast'
 
 const props = defineProps<{
   post: Post
@@ -18,25 +19,22 @@ const emit = defineEmits<{
 }>()
 
 const authStore = useAuthStore()
-const { removePost: doRemovePost } = useModeration()
+const toast = useToast()
+const { removePost: doRemovePost, restorePost: doRestorePost, lockPost: doLockPost, unlockPost: doUnlockPost, featurePost: doFeaturePost } = useModeration()
 
-const SAVE_MUTATION = `
-  mutation SavePost($postId: ID!) { savePost(postId: $postId) { id isSaved } }
-`
-const UNSAVE_MUTATION = `
-  mutation UnsavePost($postId: ID!) { unsavePost(postId: $postId) { id isSaved } }
-`
-const DELETE_MUTATION = `
-  mutation DeletePost($postId: ID!) { deletePost(postId: $postId) { id } }
-`
-const REPORT_MUTATION = `
-  mutation ReportPost($postId: ID!, $reason: String!) { reportPost(postId: $postId, reason: $reason) { success } }
-`
+const SAVE_MUTATION = `mutation SavePost($postId: ID!) { savePost(postId: $postId) { id isSaved } }`
+const UNSAVE_MUTATION = `mutation UnsavePost($postId: ID!) { unsavePost(postId: $postId) { id isSaved } }`
+const DELETE_MUTATION = `mutation DeletePost($postId: ID!) { deletePost(postId: $postId) { id } }`
+const REPORT_MUTATION = `mutation ReportPost($postId: ID!, $reason: String!) { reportPost(postId: $postId, reason: $reason) { success } }`
 
 const saved = ref(props.post.isSaved ?? false)
 const showReport = ref(false)
 const reportReason = ref('')
 const showDeleteConfirm = ref(false)
+const showModMenu = ref(false)
+const showRemoveDialog = ref(false)
+const removeReason = ref('')
+const acting = ref(false)
 
 watch(() => props.post.isSaved, (v) => { saved.value = v ?? false })
 
@@ -56,27 +54,72 @@ async function toggleSave (): Promise<void> {
   const { execute } = useGraphQL()
   const mutation = saved.value ? UNSAVE_MUTATION : SAVE_MUTATION
   const result = await execute(mutation, { variables: { postId: props.post.id } })
-  if (result) saved.value = !saved.value
+  if (result) {
+    saved.value = !saved.value
+    toast.success(saved.value ? 'Post saved' : 'Post unsaved')
+  }
 }
 
 async function submitReport (): Promise<void> {
   if (!reportReason.value.trim()) return
   const { execute } = useGraphQL()
-  await execute(REPORT_MUTATION, { variables: { postId: props.post.id, reason: reportReason.value } })
+  const result = await execute(REPORT_MUTATION, { variables: { postId: props.post.id, reason: reportReason.value } })
   showReport.value = false
   reportReason.value = ''
+  if (result) toast.success('Report submitted')
 }
 
 async function deletePost (): Promise<void> {
   const { execute } = useGraphQL()
-  await execute(DELETE_MUTATION, { variables: { postId: props.post.id } })
+  const result = await execute(DELETE_MUTATION, { variables: { postId: props.post.id } })
   showDeleteConfirm.value = false
-  emit('deleted')
+  if (result) {
+    toast.success('Post deleted')
+    emit('deleted')
+  }
 }
 
 function handleQuoteOP (): void {
   const body = props.post.body ?? ''
   emit('quote', displayName.value, body)
+}
+
+async function handleLockToggle (): Promise<void> {
+  acting.value = true
+  showModMenu.value = false
+  const success = props.post.isLocked ? await doUnlockPost(props.post.id) : await doLockPost(props.post.id)
+  acting.value = false
+  if (success) emit('post-updated')
+}
+
+async function handleFeatureToggle (): Promise<void> {
+  acting.value = true
+  showModMenu.value = false
+  const success = await doFeaturePost(props.post.id, !props.post.isFeaturedBoard, 'board')
+  acting.value = false
+  if (success) emit('post-updated')
+}
+
+async function handleRemove (): Promise<void> {
+  acting.value = true
+  const success = await doRemovePost(props.post.id, removeReason.value || undefined)
+  showRemoveDialog.value = false
+  removeReason.value = ''
+  acting.value = false
+  if (success) emit('post-updated')
+}
+
+async function handleRestore (): Promise<void> {
+  acting.value = true
+  showModMenu.value = false
+  const success = await doRestorePost(props.post.id)
+  acting.value = false
+  if (success) emit('post-updated')
+}
+
+function openRemoveDialog (): void {
+  showModMenu.value = false
+  showRemoveDialog.value = true
 }
 </script>
 
@@ -202,7 +245,7 @@ function handleQuoteOP (): void {
       </div>
     </div>
 
-    <!-- Footer -->
+    <!-- Footer: unified actions -->
     <div class="px-4 py-2 bg-gray-50 border-t border-gray-100 flex items-center justify-between flex-wrap gap-2">
       <!-- Left: reactions -->
       <CommonReactionBar target-type="post" :target-id="post.id" />
@@ -212,8 +255,8 @@ function handleQuoteOP (): void {
         <button
           v-if="authStore.isLoggedIn"
           class="inline-flex items-center gap-1 px-2 py-1 rounded hover:bg-gray-200 hover:text-gray-700 transition-colors"
-          @click="handleQuoteOP"
           title="Quote this post"
+          @click="handleQuoteOP"
         >
           <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z" />
@@ -223,34 +266,112 @@ function handleQuoteOP (): void {
 
         <template v-if="authStore.isLoggedIn">
           <button
-            class="px-2 py-1 rounded hover:bg-gray-200 hover:text-gray-700 transition-colors"
+            class="inline-flex items-center gap-1 px-2 py-1 rounded transition-colors"
+            :class="saved ? 'text-primary bg-primary/10' : 'hover:bg-gray-200 hover:text-gray-700'"
             @click="toggleSave"
           >
-            {{ saved ? 'Unsave' : 'Save' }}
+            <svg class="w-3.5 h-3.5" :fill="saved ? 'currentColor' : 'none'" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
+            </svg>
+            {{ saved ? 'Saved' : 'Save' }}
           </button>
 
           <button
             v-if="!isOwnPost"
-            class="px-2 py-1 rounded hover:bg-red-50 hover:text-red-500 transition-colors"
+            class="inline-flex items-center gap-1 px-2 py-1 rounded hover:bg-red-50 hover:text-red-500 transition-colors"
             @click="showReport = true"
           >
+            <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 21v-4m0 0V5a2 2 0 012-2h6.5l1 1H21l-3 6 3 6h-8.5l-1-1H5a2 2 0 00-2 2zm9-13.5V9" />
+            </svg>
             Report
           </button>
 
           <button
             v-if="isOwnPost"
-            class="px-2 py-1 rounded hover:bg-red-50 hover:text-red-500 transition-colors"
+            class="inline-flex items-center gap-1 px-2 py-1 rounded hover:bg-red-50 hover:text-red-500 transition-colors"
             @click="showDeleteConfirm = true"
           >
+            <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+            </svg>
             Delete
           </button>
         </template>
 
-        <CommonReactionBar target-type="post" :target-id="post.id" />
-
+        <!-- Mod actions menu -->
         <template v-if="canModerate">
           <div class="w-px h-4 bg-gray-300 mx-1" />
-          <PostModActions :post="post" @updated="emit('post-updated')" />
+          <div class="relative">
+            <button
+              class="inline-flex items-center gap-1 px-2 py-1 rounded transition-colors"
+              :class="showModMenu ? 'bg-gray-200 text-gray-700' : 'hover:bg-gray-200 hover:text-gray-700'"
+              @click="showModMenu = !showModMenu"
+            >
+              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+              </svg>
+              Mod
+            </button>
+
+            <Teleport to="body">
+              <div v-if="showModMenu" class="fixed inset-0 z-40" @click="showModMenu = false" />
+            </Teleport>
+            <div
+              v-if="showModMenu"
+              class="absolute right-0 top-full mt-1 w-48 bg-white rounded-lg border border-gray-200 shadow-lg z-50 py-1"
+            >
+              <div class="px-3 py-1.5 text-[10px] font-semibold text-gray-400 uppercase tracking-wider">
+                Moderation
+              </div>
+              <button
+                class="w-full flex items-center gap-2 px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                :disabled="acting"
+                @click="handleLockToggle"
+              >
+                <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path v-if="post.isLocked" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 11V7a4 4 0 118 0m-4 8v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2z" />
+                  <path v-else stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+                </svg>
+                {{ post.isLocked ? 'Unlock' : 'Lock' }}
+              </button>
+              <button
+                class="w-full flex items-center gap-2 px-3 py-2 text-sm transition-colors"
+                :class="post.isFeaturedBoard ? 'text-green-700 hover:bg-green-50' : 'text-gray-700 hover:bg-gray-50'"
+                :disabled="acting"
+                @click="handleFeatureToggle"
+              >
+                <svg class="w-4 h-4" :class="post.isFeaturedBoard ? 'text-green-500' : 'text-gray-400'" fill="currentColor" viewBox="0 0 20 20">
+                  <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+                </svg>
+                {{ post.isFeaturedBoard ? 'Unpin' : 'Pin' }}
+              </button>
+              <div class="border-t border-gray-100 my-1" />
+              <button
+                v-if="!post.isRemoved"
+                class="w-full flex items-center gap-2 px-3 py-2 text-sm text-red-600 hover:bg-red-50 transition-colors"
+                :disabled="acting"
+                @click="openRemoveDialog"
+              >
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" />
+                </svg>
+                Remove
+              </button>
+              <button
+                v-else
+                class="w-full flex items-center gap-2 px-3 py-2 text-sm text-green-600 hover:bg-green-50 transition-colors"
+                :disabled="acting"
+                @click="handleRestore"
+              >
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                </svg>
+                Restore
+              </button>
+            </div>
+          </div>
         </template>
       </div>
     </div>
@@ -281,6 +402,26 @@ function handleQuoteOP (): void {
           <div class="flex gap-2 justify-end">
             <button class="button white button-sm" @click="showDeleteConfirm = false">Cancel</button>
             <button class="button button-sm bg-red-600 text-white hover:bg-red-700" @click="deletePost">Delete</button>
+          </div>
+        </div>
+      </template>
+    </CommonModal>
+
+    <!-- Remove reason dialog -->
+    <CommonModal v-if="showRemoveDialog" @close="showRemoveDialog = false">
+      <template #title>Remove Post</template>
+      <template #default>
+        <div class="space-y-3">
+          <p class="text-sm text-gray-600">Are you sure you want to remove this post?</p>
+          <div>
+            <label class="block text-sm font-medium text-gray-700 mb-1">Reason (optional)</label>
+            <input v-model="removeReason" type="text" class="form-input" placeholder="Reason for removal..." />
+          </div>
+          <div class="flex gap-2 justify-end">
+            <button class="button white button-sm" @click="showRemoveDialog = false">Cancel</button>
+            <button class="button button-sm bg-red-600 text-white hover:bg-red-700" :disabled="acting" @click="handleRemove">
+              {{ acting ? 'Removing...' : 'Remove Post' }}
+            </button>
           </div>
         </div>
       </template>

--- a/frontend/composables/usePosts.ts
+++ b/frontend/composables/usePosts.ts
@@ -28,6 +28,7 @@ const POSTS_QUERY = `
       downvotes
       commentCount
       myVote
+      isSaved
       image
       altText
       embedTitle

--- a/frontend/composables/useStreamFeed.ts
+++ b/frontend/composables/useStreamFeed.ts
@@ -6,7 +6,7 @@ const STREAM_FEED_QUERY = `
   query GetStreamFeed($boardName: String, $sort: SortType, $page: Int, $limit: Int) {
     listPosts(boardName: $boardName, sort: $sort, page: $page, limit: $limit) {
       id title body url createdAt updatedAt isDeleted isRemoved isLocked isFeaturedBoard isNSFW slug
-      score upvotes downvotes commentCount myVote
+      score upvotes downvotes commentCount myVote isSaved
       board { id name title icon }
       creator { id name displayName avatar }
     }

--- a/frontend/pages/@[username]/comments.vue
+++ b/frontend/pages/@[username]/comments.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { useGraphQL } from '~/composables/useGraphQL'
 import type { Comment } from '~/types/generated'
+import { timeAgo } from '~/utils/date'
 
 const route = useRoute()
 const username = computed(() => route.params.username as string)
@@ -19,6 +20,8 @@ const USER_COMMENTS_QUERY = `
       postId
       boardId
       creator { id name displayName avatar }
+      post { id title slug board { id name } }
+      board { id name title }
     }
   }
 `
@@ -88,14 +91,54 @@ await fetchComments()
       <div
         v-for="comment in comments"
         :key="comment.id"
-        class="bg-white border border-gray-200 rounded-lg p-3"
+        class="bg-white border border-gray-200 rounded-lg overflow-hidden"
       >
-        <div class="flex items-center gap-2 text-xs text-gray-500 mb-1">
-          <span>{{ comment.score }} points</span>
-          <span>&middot;</span>
-          <span>{{ comment.createdAt }}</span>
+        <!-- Context header: which post & board this comment is on -->
+        <div v-if="comment.post || comment.board" class="px-3 py-2 bg-gray-50 border-b border-gray-100 flex items-center gap-1.5 text-xs text-gray-500">
+          <svg class="w-3.5 h-3.5 text-gray-400 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6" />
+          </svg>
+          <span class="text-gray-400">commented on</span>
+          <NuxtLink
+            v-if="comment.post"
+            :to="`/b/${comment.post.board?.name || comment.board?.name || 'unknown'}/feed/${comment.postId}/${comment.post.slug || ''}`"
+            class="font-medium text-gray-700 no-underline hover:text-primary truncate"
+          >
+            {{ comment.post.title }}
+          </NuxtLink>
+          <span v-if="comment.board || comment.post?.board" class="text-gray-400 shrink-0">in</span>
+          <NuxtLink
+            v-if="comment.board || comment.post?.board"
+            :to="`/b/${comment.post?.board?.name || comment.board?.name}`"
+            class="font-medium text-primary no-underline hover:underline shrink-0"
+          >
+            b/{{ comment.post?.board?.name || comment.board?.name }}
+          </NuxtLink>
         </div>
-        <p class="text-sm text-gray-800">{{ comment.body }}</p>
+
+        <!-- Comment content -->
+        <div class="p-3">
+          <div class="flex items-center gap-2 text-xs text-gray-500 mb-1.5">
+            <span class="inline-flex items-center gap-1" :class="comment.score > 0 ? 'text-primary' : comment.score < 0 ? 'text-red-400' : ''">
+              <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7" />
+              </svg>
+              {{ comment.score }} {{ comment.score === 1 ? 'point' : 'points' }}
+            </span>
+            <span>&middot;</span>
+            <time :datetime="comment.createdAt" :title="comment.createdAt">{{ timeAgo(comment.createdAt) }}</time>
+            <template v-if="comment.replyCount > 0">
+              <span>&middot;</span>
+              <span class="inline-flex items-center gap-1">
+                <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+                </svg>
+                {{ comment.replyCount }} {{ comment.replyCount === 1 ? 'reply' : 'replies' }}
+              </span>
+            </template>
+          </div>
+          <p class="text-sm text-gray-800 leading-relaxed">{{ comment.body }}</p>
+        </div>
       </div>
     </div>
     <p v-else class="text-sm text-gray-500 text-center py-8">

--- a/frontend/pages/@[username]/index.vue
+++ b/frontend/pages/@[username]/index.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { useGraphQL } from '~/composables/useGraphQL'
 import type { Post, Comment } from '~/types/generated'
+import { timeAgo } from '~/utils/date'
 
 const route = useRoute()
 const username = computed(() => route.params.username as string)
@@ -17,6 +18,7 @@ const RECENT_POSTS_QUERY = `
       score
       commentCount
       myVote
+      isSaved
       board { id name title icon }
       creator { id name displayName avatar }
     }
@@ -30,12 +32,12 @@ const RECENT_COMMENTS_QUERY = `
       body
       createdAt
       score
-      upvotes
-      downvotes
       replyCount
       postId
       boardId
       creator { id name displayName avatar }
+      post { id title slug board { id name } }
+      board { id name title }
     }
   }
 `
@@ -121,14 +123,44 @@ await loadContent(username.value)
         <div
           v-for="comment in recentComments"
           :key="comment.id"
-          class="bg-white border border-gray-200 rounded-lg p-3"
+          class="bg-white border border-gray-200 rounded-lg overflow-hidden"
         >
-          <div class="flex items-center gap-2 text-xs text-gray-500 mb-1">
-            <span>{{ comment.score }} points</span>
-            <span>&middot;</span>
-            <span>{{ comment.createdAt }}</span>
+          <!-- Context header -->
+          <div v-if="comment.post || comment.board" class="px-3 py-2 bg-gray-50 border-b border-gray-100 flex items-center gap-1.5 text-xs text-gray-500">
+            <svg class="w-3.5 h-3.5 text-gray-400 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6" />
+            </svg>
+            <span class="text-gray-400">commented on</span>
+            <NuxtLink
+              v-if="comment.post"
+              :to="`/b/${comment.post.board?.name || comment.board?.name || 'unknown'}/feed/${comment.postId}/${comment.post.slug || ''}`"
+              class="font-medium text-gray-700 no-underline hover:text-primary truncate"
+            >
+              {{ comment.post.title }}
+            </NuxtLink>
+            <span v-if="comment.board || comment.post?.board" class="text-gray-400 shrink-0">in</span>
+            <NuxtLink
+              v-if="comment.board || comment.post?.board"
+              :to="`/b/${comment.post?.board?.name || comment.board?.name}`"
+              class="font-medium text-primary no-underline hover:underline shrink-0"
+            >
+              b/{{ comment.post?.board?.name || comment.board?.name }}
+            </NuxtLink>
           </div>
-          <p class="text-sm text-gray-800 line-clamp-3">{{ comment.body }}</p>
+          <!-- Comment body -->
+          <div class="p-3">
+            <div class="flex items-center gap-2 text-xs text-gray-500 mb-1.5">
+              <span class="inline-flex items-center gap-1" :class="comment.score > 0 ? 'text-primary' : comment.score < 0 ? 'text-red-400' : ''">
+                <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7" />
+                </svg>
+                {{ comment.score }} {{ comment.score === 1 ? 'point' : 'points' }}
+              </span>
+              <span>&middot;</span>
+              <time :datetime="comment.createdAt" :title="comment.createdAt">{{ timeAgo(comment.createdAt) }}</time>
+            </div>
+            <p class="text-sm text-gray-800 line-clamp-3 leading-relaxed">{{ comment.body }}</p>
+          </div>
         </div>
       </div>
       <div v-else-if="!commentsLoading" class="bg-white rounded-lg border border-gray-200 py-8 text-center">

--- a/frontend/pages/@[username]/posts.vue
+++ b/frontend/pages/@[username]/posts.vue
@@ -25,6 +25,7 @@ const USER_POSTS_QUERY = `
       downvotes
       commentCount
       myVote
+      isSaved
       board { id name title icon }
       creator { id name displayName avatar }
     }

--- a/frontend/pages/@[username]/saved.vue
+++ b/frontend/pages/@[username]/saved.vue
@@ -31,6 +31,7 @@ const SAVED_POSTS_QUERY = `
       downvotes
       commentCount
       myVote
+      isSaved
       board { id name title icon }
       creator { id name displayName avatar }
     }

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -171,6 +171,7 @@ type Mutation {
   voteOnComment(commentId: ID!, direction: Int!): Comment!
   saveComment(commentId: ID!): Comment!
   unsaveComment(commentId: ID!): Comment!
+  pinComment(commentId: ID!): Comment!
   removeComment(commentId: ID!, reason: String): Comment!
   restoreComment(commentId: ID!): Comment!
 
@@ -305,6 +306,8 @@ type Post {
   newestCommentTime: String!
   hotRank: Int!
   urlPath: String!
+  isThread: Boolean!
+  isSaved: Boolean!
   creator: User
   board: Board
   myVote: Int!
@@ -336,6 +339,7 @@ type Comment {
   board: Board
   post: Post!
   myVote: Int!
+  isSaved: Boolean!
 }
 
 type Board {


### PR DESCRIPTION
… feedback

Profile comments:
- Show parent post title and board name in context header
- Use timeAgo formatting with proper icons for score/replies

Post actions (PostCard, PostDetail, ThreadDetailHeader):
- Implement working save/unsave button on PostCard with toast notification
- Unify user actions and mod actions into single action bar on PostDetail
- Replace separate PostModActions row with dropdown menu triggered by "Mod" button containing lock, pin, remove/restore actions
- Add toast notifications for save, report, delete operations
- Add isSaved field to all post list queries (usePosts, useStreamFeed, profile pages)

Comment actions:
- Replace plain text "upvote/downvote" with arrow icon buttons
- Add save/unsave button with toast feedback
- Add proper icons for reply, report, save actions
- Move mod actions (pin, remove, restore) into dropdown menu
- Add toast notifications for report submission and pin toggle

Schema:
- Add isSaved, isThread fields to frontend Post type
- Add isSaved field to frontend Comment type
- Add pinComment mutation to frontend schema