### PR TITLE
fix(media): render uploaded videos with native player and fix persist…

### DIFF
--- a/backend/crates/utils/src/settings/structs.rs
+++ b/backend/crates/utils/src/settings/structs.rs
@@ -153,7 +153,7 @@ pub struct EmailConfig {
 #[serde(default)]
 pub struct MediaConfig {
   /// media file path to which uploads will be stored and served from
-  #[default("/app/tinyboards/media")]
+  #[default("/app/media")]
   pub media_path: String,
   /// maximum file size in megabytes for uploads (general default)
   #[default(50)]

--- a/backend/src/media_handler.rs
+++ b/backend/src/media_handler.rs
@@ -1,11 +1,13 @@
 use actix_web::{web, HttpRequest, HttpResponse, Result};
+use actix_web::http::header;
 use tinyboards_api::context::TinyBoardsContext;
 use tinyboards_utils::error::TinyBoardsError;
 use std::path::PathBuf;
 use tokio::fs;
 
-/// Serves media files from the configured storage backend
-/// First checks local filesystem for backwards compatibility, then falls back to storage backend
+/// Serves media files from the configured storage backend.
+/// First checks local filesystem for backwards compatibility, then falls back to storage backend.
+/// Supports HTTP Range requests for video seeking.
 pub async fn serve_media(
     context: web::Data<TinyBoardsContext>,
     req: HttpRequest,
@@ -22,36 +24,85 @@ pub async fn serve_media(
     let media_path = context.settings().get_media_path();
     let local_path = PathBuf::from(&media_path).join(storage_key);
 
-    if local_path.exists() {
+    let data = if local_path.exists() {
         tracing::debug!("Found file locally at: {:?}", local_path);
         match fs::read(&local_path).await {
-            Ok(data) => {
-                let content_type = get_content_type(storage_key);
-                return Ok(HttpResponse::Ok()
-                    .content_type(content_type)
-                    .body(data));
-            }
+            Ok(data) => data,
             Err(e) => {
                 tracing::warn!("File exists but failed to read locally: {:?}", e);
                 // Fall through to storage backend
+                context.storage().read(storage_key).await
+                    .map_err(|e| {
+                        tracing::error!("Failed to read file from storage backend: {:?}", e);
+                        TinyBoardsError::from_message(404, "File not found")
+                    })?
+            }
+        }
+    } else {
+        // Try the configured storage backend
+        tracing::debug!("File not found locally, checking storage backend");
+        context.storage().read(storage_key).await
+            .map_err(|e| {
+                tracing::error!("Failed to read file from storage backend: {:?}", e);
+                TinyBoardsError::from_message(404, "File not found")
+            })?
+    };
+
+    let content_type = get_content_type(storage_key);
+    let total_len = data.len();
+
+    // Parse Range header for partial content (needed for video seeking)
+    if let Some(range_header) = req.headers().get(header::RANGE) {
+        if let Ok(range_str) = range_header.to_str() {
+            if let Some(range) = parse_range(range_str, total_len) {
+                let (start, end) = range;
+                let slice = data[start..=end].to_vec();
+                return Ok(HttpResponse::PartialContent()
+                    .content_type(content_type)
+                    .insert_header((header::CONTENT_LENGTH, (end - start + 1).to_string()))
+                    .insert_header((header::ACCEPT_RANGES, "bytes"))
+                    .insert_header((
+                        header::CONTENT_RANGE,
+                        format!("bytes {}-{}/{}", start, end, total_len),
+                    ))
+                    .body(slice));
             }
         }
     }
 
-    // If not found locally, try the configured storage backend
-    tracing::debug!("File not found locally, checking storage backend");
-    let data = context.storage().read(storage_key).await
-        .map_err(|e| {
-            tracing::error!("Failed to read file from storage backend: {:?}", e);
-            TinyBoardsError::from_message(404, "File not found")
-        })?;
-
-    // Determine content type from file extension
-    let content_type = get_content_type(storage_key);
-
     Ok(HttpResponse::Ok()
         .content_type(content_type)
+        .insert_header((header::CONTENT_LENGTH, total_len.to_string()))
+        .insert_header((header::ACCEPT_RANGES, "bytes"))
         .body(data))
+}
+
+/// Parse a simple "bytes=start-end" range header.
+/// Returns (start, end) inclusive, or None if the range is invalid.
+fn parse_range(range_str: &str, total: usize) -> Option<(usize, usize)> {
+    let range_str = range_str.strip_prefix("bytes=")?;
+    let mut parts = range_str.splitn(2, '-');
+    let start_str = parts.next()?.trim();
+    let end_str = parts.next()?.trim();
+
+    if start_str.is_empty() {
+        // Suffix range: bytes=-500 means last 500 bytes
+        let suffix_len: usize = end_str.parse().ok()?;
+        let start = total.saturating_sub(suffix_len);
+        Some((start, total - 1))
+    } else {
+        let start: usize = start_str.parse().ok()?;
+        let end = if end_str.is_empty() {
+            total - 1
+        } else {
+            end_str.parse::<usize>().ok()?.min(total - 1)
+        };
+        if start <= end && start < total {
+            Some((start, end))
+        } else {
+            None
+        }
+    }
 }
 
 /// Determine content type from file extension

--- a/frontend/components/post/PostCard.vue
+++ b/frontend/components/post/PostCard.vue
@@ -58,10 +58,18 @@ const isYouTubeEmbed = computed(() => {
   }
 })
 
+const VIDEO_EXT_RE = /\.(mp4|webm|ogg|mov)$/i
+
 const isDirectVideo = computed(() => {
   const url = props.post.embedVideoUrl
   if (!url || isYouTubeEmbed.value) return false
-  return /\.(mp4|webm|ogg)$/i.test(url)
+  return VIDEO_EXT_RE.test(url)
+})
+
+const isImageVideo = computed(() => {
+  const url = props.post.image
+  if (!url) return false
+  return VIDEO_EXT_RE.test(url)
 })
 
 const hasLinkPreview = computed(() => {
@@ -260,9 +268,20 @@ const hasLinkPreview = computed(() => {
             loading="lazy"
           />
 
+          <!-- Post video (uploaded video file) -->
+          <div v-if="isImageVideo" class="mt-2 max-w-lg">
+            <video
+              :src="post.image!"
+              class="w-full rounded-lg"
+              controls
+              preload="metadata"
+              :alt="post.altText || post.title"
+            />
+          </div>
+
           <!-- Post image -->
           <img
-            v-if="post.image && !post.thumbnailUrl"
+            v-if="post.image && !post.thumbnailUrl && !isImageVideo"
             :src="post.image"
             :alt="post.altText || post.title"
             class="mt-2 max-w-sm max-h-64 rounded-lg object-cover"

--- a/frontend/components/post/PostDetail.vue
+++ b/frontend/components/post/PostDetail.vue
@@ -40,6 +40,10 @@ watch(() => props.post.isSaved, (v) => { saved.value = v ?? false })
 
 const isOwnPost = computed(() => authStore.user?.id === props.post.creator?.id)
 const canModerate = computed(() => props.isModerator || authStore.isAdmin)
+const isImageVideo = computed(() => {
+  const url = props.post.image
+  return !!url && /\.(mp4|webm|ogg|mov)$/i.test(url)
+})
 
 async function toggleSave (): Promise<void> {
   const { execute } = useGraphQL()
@@ -137,8 +141,18 @@ function onClickOutsideMenu (e: Event): void {
           {{ post.url }}
         </a>
 
+        <!-- Video display (uploaded video file) -->
+        <div v-if="post.image && isImageVideo" class="mt-3">
+          <video
+            :src="post.image"
+            class="max-w-full max-h-[600px] rounded-lg border border-gray-200"
+            controls
+            preload="metadata"
+          />
+        </div>
+
         <!-- Image display -->
-        <div v-if="post.image" class="mt-3">
+        <div v-if="post.image && !isImageVideo" class="mt-3">
           <img
             :src="post.image"
             :alt="post.altText || post.title"

--- a/frontend/components/thread/ThreadDetailHeader.vue
+++ b/frontend/components/thread/ThreadDetailHeader.vue
@@ -40,6 +40,10 @@ watch(() => props.post.isSaved, (v) => { saved.value = v ?? false })
 
 const isOwnPost = computed(() => authStore.user?.id === props.post.creator?.id)
 const canModerate = computed(() => props.isModerator || authStore.isAdmin)
+const isImageVideo = computed(() => {
+  const url = props.post.image
+  return !!url && /\.(mp4|webm|ogg|mov)$/i.test(url)
+})
 
 const displayName = computed(() => {
   if (!props.post.creator) return '[deleted]'
@@ -213,8 +217,18 @@ function openRemoveDialog (): void {
           {{ post.url }}
         </a>
 
+        <!-- Video (uploaded video file) -->
+        <div v-if="post.image && isImageVideo" class="mb-3">
+          <video
+            :src="post.image"
+            class="max-w-full max-h-[600px] rounded-lg border border-gray-200"
+            controls
+            preload="metadata"
+          />
+        </div>
+
         <!-- Image -->
-        <div v-if="post.image" class="mb-3">
+        <div v-if="post.image && !isImageVideo" class="mb-3">
           <img
             :src="post.image"
             :alt="post.altText || post.title"


### PR DESCRIPTION
…ence

Videos uploaded to posts were rendered as <img> tags, causing browsers to autoplay them without controls. Now detect video file extensions in post.image and render with <video controls preload="metadata"> in PostCard, PostDetail, and ThreadDetailHeader.

Fix default media_path to /app/media to match the Docker volume mount (was /app/tinyboards/media, which is outside the persistent volume and lost on container recreation).

Add HTTP Range request support to the media handler so browsers can seek within video files, and include Accept-Ranges/Content-Length headers.