### PR TITLE
style(ui): widen feed layout, enrich sidebar, improve post card hiera…

### DIFF
--- a/frontend/components/layout/AppSidebar.vue
+++ b/frontend/components/layout/AppSidebar.vue
@@ -23,10 +23,10 @@ const currentSection = computed<SidebarSection>(() => {
 
 <template>
   <aside
-    class="w-[290px] shrink-0 overflow-y-auto"
+    class="w-80 shrink-0"
     :class="{ 'hidden lg:block': !uiStore.sidebarOpen }"
   >
-    <div class="p-4">
+    <div class="sticky top-4 space-y-0 max-h-[calc(100vh-5rem)] overflow-y-auto py-4 pr-1">
       <SidebarHomeSidebar v-if="currentSection === 'home'" />
       <SidebarAllSidebar v-else-if="currentSection === 'all'" />
       <SidebarBoardPageSidebar v-else-if="currentSection === 'board'" />

--- a/frontend/components/post/PostActions.vue
+++ b/frontend/components/post/PostActions.vue
@@ -85,7 +85,7 @@ async function vote (score: number): Promise<void> {
     </button>
 
     <span
-      class="font-bold text-xs min-w-[2ch] text-center tabular-nums select-none transition-colors"
+      class="font-semibold text-sm min-w-[2ch] text-center tabular-nums select-none transition-colors"
       :class="[
         localMyVote === 1 ? 'text-primary' : localMyVote === -1 ? 'text-secondary' : 'text-gray-700',
         scorePop ? 'score-pop' : ''

--- a/frontend/components/post/PostCard.vue
+++ b/frontend/components/post/PostCard.vue
@@ -97,7 +97,7 @@ const hasLinkPreview = computed(() => {
           <a
             v-if="post.url"
             :href="post.url"
-            class="text-gray-900 no-underline group-hover:text-primary transition-colors font-normal"
+            class="text-gray-900 no-underline group-hover:text-primary transition-colors font-semibold"
             target="_blank"
             rel="noopener noreferrer"
           >
@@ -106,11 +106,11 @@ const hasLinkPreview = computed(() => {
           <NuxtLink
             v-else
             :to="postUrl(post)"
-            class="text-gray-900 no-underline group-hover:text-primary transition-colors font-normal"
+            class="text-gray-900 no-underline group-hover:text-primary transition-colors font-semibold"
           >
             {{ post.title }}
           </NuxtLink>
-          <span v-if="post.url" class="text-xs text-gray-400 ml-1">({{ linkHostname }})</span>
+          <span v-if="post.url" class="text-xs text-gray-400 ml-1 font-normal">({{ linkHostname }})</span>
         </h3>
 
         <!-- Badges -->
@@ -158,7 +158,7 @@ const hasLinkPreview = computed(() => {
         <NuxtLink
           v-if="post.board"
           :to="`/b/${post.board.name}`"
-          class="text-xs font-medium text-gray-500 no-underline hover:text-primary shrink-0 hidden sm:inline"
+          class="text-xs font-medium text-primary/80 no-underline hover:text-primary shrink-0 hidden sm:inline"
         >
           b/{{ post.board.name }}
         </NuxtLink>
@@ -169,10 +169,10 @@ const hasLinkPreview = computed(() => {
     <template v-else>
       <div class="flex">
         <!-- Vote column (only for non-thread posts) -->
-        <PostActions v-if="!isThread" :post="post" layout="vertical" class="px-2 py-3 border-r border-gray-100 bg-gray-50/50 rounded-l-lg" />
+        <PostActions v-if="!isThread" :post="post" layout="vertical" class="w-12 shrink-0 px-2 py-3 border-r border-gray-100 bg-gray-50/50 rounded-l-lg" />
 
         <!-- Content -->
-        <div class="flex-1 min-w-0 p-3">
+        <div class="flex-1 min-w-0 p-3 lg:p-4">
           <!-- Author line with avatar -->
           <div class="flex items-center gap-2 mb-1.5">
             <CommonAvatar
@@ -215,11 +215,11 @@ const hasLinkPreview = computed(() => {
           </div>
 
           <!-- Title -->
-          <h3 class="text-base leading-snug mb-0.5">
+          <h3 class="text-base leading-snug mb-1">
             <a
               v-if="post.url"
               :href="post.url"
-              class="text-gray-900 no-underline group-hover:text-primary transition-colors font-normal"
+              class="text-gray-900 no-underline group-hover:text-primary transition-colors font-semibold"
               target="_blank"
               rel="noopener noreferrer"
             >
@@ -228,7 +228,7 @@ const hasLinkPreview = computed(() => {
             <NuxtLink
               v-else
               :to="postUrl(post)"
-              class="text-gray-900 no-underline group-hover:text-primary transition-colors font-normal"
+              class="text-gray-900 no-underline group-hover:text-primary transition-colors font-semibold"
             >
               {{ post.title }}
             </NuxtLink>
@@ -354,7 +354,7 @@ const hasLinkPreview = computed(() => {
             <NuxtLink
               v-if="post.board"
               :to="`/b/${post.board.name}`"
-              class="ml-auto inline-flex items-center gap-1 font-medium text-gray-500 no-underline hover:text-primary transition-colors"
+              class="ml-auto inline-flex items-center gap-1 font-medium text-primary/80 no-underline hover:text-primary transition-colors"
             >
               b/{{ post.board.name }}
             </NuxtLink>

--- a/frontend/components/post/PostList.vue
+++ b/frontend/components/post/PostList.vue
@@ -25,7 +25,7 @@ const isCompact = computed(() => uiStore.postViewMode === 'compact')
       <p class="text-xs text-gray-400">Be the first to start a conversation!</p>
     </div>
 
-    <div v-else :class="isCompact ? 'space-y-1' : 'space-y-2'" class="relative">
+    <div v-else :class="isCompact ? 'space-y-1' : 'space-y-3'" class="relative">
       <div v-if="loading" class="absolute inset-0 bg-white/50 z-10 flex items-start justify-center pt-8 rounded-lg">
         <CommonLoadingSpinner size="md" />
       </div>

--- a/frontend/components/sidebar/AllSidebar.vue
+++ b/frontend/components/sidebar/AllSidebar.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
+import { useAuthStore } from '~/stores/auth'
 import { useSiteStore } from '~/stores/site'
 import { useGraphQL } from '~/composables/useGraphQL'
 import type { Board } from '~/types/generated'
 
+const authStore = useAuthStore()
 const siteStore = useSiteStore()
 
 const TRENDING_BOARDS_QUERY = `
@@ -18,12 +20,21 @@ const TRENDING_BOARDS_QUERY = `
   }
 `
 
+const SITE_STATS_QUERY = `
+  query { siteStats { users posts comments boards usersActiveDay } }
+`
+
 interface TrendingResponse {
   listBoards: Board[]
 }
 
+interface SiteStatsResponse {
+  siteStats: { users: number; posts: number; comments: number; boards: number; usersActiveDay: number }
+}
+
 const { execute } = useGraphQL<TrendingResponse>()
 const trendingBoards = ref<Board[]>([])
+const siteStats = ref<SiteStatsResponse['siteStats'] | null>(null)
 
 async function fetchTrending (): Promise<void> {
   const result = await execute(TRENDING_BOARDS_QUERY, {
@@ -34,11 +45,37 @@ async function fetchTrending (): Promise<void> {
   }
 }
 
-await fetchTrending()
+async function fetchStats (): Promise<void> {
+  const { execute: execStats } = useGraphQL<SiteStatsResponse>()
+  const result = await execStats(SITE_STATS_QUERY)
+  if (result?.siteStats) {
+    siteStats.value = result.siteStats
+  }
+}
+
+await Promise.all([fetchTrending(), fetchStats()])
+
+function formatCount (n: number): string {
+  if (n >= 1000000) return `${(n / 1000000).toFixed(1)}M`
+  if (n >= 1000) return `${(n / 1000).toFixed(1)}K`
+  return String(n)
+}
 </script>
 
 <template>
-  <div class="space-y-5">
+  <div class="space-y-4">
+    <!-- New Post button for logged-in users -->
+    <NuxtLink
+      v-if="authStore.isLoggedIn"
+      to="/submit"
+      class="flex items-center justify-center gap-2 w-full rounded-lg bg-primary text-white py-2.5 text-sm font-medium hover:opacity-90 transition-opacity no-underline"
+    >
+      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+      </svg>
+      New Post
+    </NuxtLink>
+
     <!-- All posts info card -->
     <div class="bg-white rounded-lg border border-gray-200 overflow-hidden">
       <div class="h-16 bg-gradient-to-br from-blue-500 to-indigo-600" />
@@ -52,6 +89,35 @@ await fetchTrending()
         <p class="text-xs text-gray-500 mt-1 leading-relaxed">
           Everything happening across {{ siteStore.name }}. Posts from every board in one feed.
         </p>
+      </div>
+    </div>
+
+    <!-- Site Stats -->
+    <div v-if="siteStats" class="bg-white rounded-lg border border-gray-200 p-3">
+      <h4 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">
+        Site Stats
+      </h4>
+      <div class="grid grid-cols-2 gap-2">
+        <div class="text-center py-1">
+          <div class="text-lg font-semibold text-gray-900">{{ formatCount(siteStats.users) }}</div>
+          <div class="text-xs text-gray-500">Members</div>
+        </div>
+        <div class="text-center py-1">
+          <div class="text-lg font-semibold text-gray-900">{{ formatCount(siteStats.posts) }}</div>
+          <div class="text-xs text-gray-500">Posts</div>
+        </div>
+        <div class="text-center py-1">
+          <div class="text-lg font-semibold text-gray-900">{{ formatCount(siteStats.comments) }}</div>
+          <div class="text-xs text-gray-500">Comments</div>
+        </div>
+        <div class="text-center py-1">
+          <div class="text-lg font-semibold text-gray-900">{{ formatCount(siteStats.boards) }}</div>
+          <div class="text-xs text-gray-500">Boards</div>
+        </div>
+      </div>
+      <div v-if="siteStats.usersActiveDay > 0" class="mt-2 pt-2 border-t border-gray-100 flex items-center justify-center gap-1.5 text-xs text-gray-500">
+        <span class="inline-block w-1.5 h-1.5 rounded-full bg-green-400" />
+        {{ siteStats.usersActiveDay }} online now
       </div>
     </div>
 
@@ -97,7 +163,30 @@ await fetchTrending()
             Browse Boards
           </NuxtLink>
         </li>
+        <li>
+          <NuxtLink to="/home" class="flex items-center gap-2.5 px-2 py-1.5 text-sm text-gray-600 rounded-md hover:bg-gray-100 hover:text-gray-900 no-underline transition-colors">
+            <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+            </svg>
+            Home Feed
+          </NuxtLink>
+        </li>
+        <li>
+          <NuxtLink to="/members" class="flex items-center gap-2.5 px-2 py-1.5 text-sm text-gray-600 rounded-md hover:bg-gray-100 hover:text-gray-900 no-underline transition-colors">
+            <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
+            </svg>
+            Members
+          </NuxtLink>
+        </li>
       </ul>
+    </div>
+
+    <!-- Footer links -->
+    <div class="border-t border-gray-200 pt-3">
+      <p class="text-[10px] text-gray-400 leading-relaxed">
+        Powered by TinyBoards &mdash; a self-hosted community platform.
+      </p>
     </div>
   </div>
 </template>

--- a/frontend/components/sidebar/HomeSidebar.vue
+++ b/frontend/components/sidebar/HomeSidebar.vue
@@ -20,12 +20,22 @@ const TRENDING_BOARDS_QUERY = `
   }
 `
 
+const SITE_STATS_QUERY = `
+  query { siteStats { users posts comments boards usersActiveDay } }
+`
+
 interface TrendingResponse {
   listBoards: Board[]
 }
 
+interface SiteStatsResponse {
+  siteStats: { users: number; posts: number; comments: number; boards: number; usersActiveDay: number }
+}
+
 const { execute, loading } = useGraphQL<TrendingResponse>()
 const trendingBoards = ref<Board[]>([])
+const siteStats = ref<SiteStatsResponse['siteStats'] | null>(null)
+
 async function fetchTrending (): Promise<void> {
   const result = await execute(TRENDING_BOARDS_QUERY, {
     variables: { limit: 5, sort: 'active' },
@@ -35,11 +45,37 @@ async function fetchTrending (): Promise<void> {
   }
 }
 
-await fetchTrending()
+async function fetchStats (): Promise<void> {
+  const { execute: execStats } = useGraphQL<SiteStatsResponse>()
+  const result = await execStats(SITE_STATS_QUERY)
+  if (result?.siteStats) {
+    siteStats.value = result.siteStats
+  }
+}
+
+await Promise.all([fetchTrending(), fetchStats()])
+
+function formatCount (n: number): string {
+  if (n >= 1000000) return `${(n / 1000000).toFixed(1)}M`
+  if (n >= 1000) return `${(n / 1000).toFixed(1)}K`
+  return String(n)
+}
 </script>
 
 <template>
-  <div class="space-y-5">
+  <div class="space-y-4">
+    <!-- New Post button for logged-in users -->
+    <NuxtLink
+      v-if="authStore.isLoggedIn"
+      to="/submit"
+      class="flex items-center justify-center gap-2 w-full rounded-lg bg-primary text-white py-2.5 text-sm font-medium hover:opacity-90 transition-opacity no-underline"
+    >
+      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+      </svg>
+      New Post
+    </NuxtLink>
+
     <!-- Site welcome card -->
     <div class="bg-white rounded-lg border border-gray-200 overflow-hidden">
       <div class="h-16 bg-gradient-to-br from-primary to-primary-hover" />
@@ -62,13 +98,42 @@ await fetchTrending()
       </div>
     </div>
 
+    <!-- Site Stats -->
+    <div v-if="siteStats" class="bg-white rounded-lg border border-gray-200 p-3">
+      <h4 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">
+        Site Stats
+      </h4>
+      <div class="grid grid-cols-2 gap-2">
+        <div class="text-center py-1">
+          <div class="text-lg font-semibold text-gray-900">{{ formatCount(siteStats.users) }}</div>
+          <div class="text-xs text-gray-500">Members</div>
+        </div>
+        <div class="text-center py-1">
+          <div class="text-lg font-semibold text-gray-900">{{ formatCount(siteStats.posts) }}</div>
+          <div class="text-xs text-gray-500">Posts</div>
+        </div>
+        <div class="text-center py-1">
+          <div class="text-lg font-semibold text-gray-900">{{ formatCount(siteStats.comments) }}</div>
+          <div class="text-xs text-gray-500">Comments</div>
+        </div>
+        <div class="text-center py-1">
+          <div class="text-lg font-semibold text-gray-900">{{ formatCount(siteStats.boards) }}</div>
+          <div class="text-xs text-gray-500">Boards</div>
+        </div>
+      </div>
+      <div v-if="siteStats.usersActiveDay > 0" class="mt-2 pt-2 border-t border-gray-100 flex items-center justify-center gap-1.5 text-xs text-gray-500">
+        <span class="inline-block w-1.5 h-1.5 rounded-full bg-green-400" />
+        {{ siteStats.usersActiveDay }} online now
+      </div>
+    </div>
+
     <!-- Your boards -->
     <div v-if="authStore.isLoggedIn && authStore.subscribedBoards?.length > 0">
       <h4 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2 px-1">
         Your Boards
       </h4>
       <ul class="space-y-0.5">
-        <li v-for="board in authStore.subscribedBoards" :key="board.name">
+        <li v-for="board in authStore.subscribedBoards.slice(0, 8)" :key="board.name">
           <NuxtLink
             :to="`/b/${board.name}`"
             class="flex items-center gap-2.5 px-2 py-1.5 text-sm text-gray-700 rounded-md hover:bg-gray-100 no-underline transition-colors"
@@ -83,6 +148,13 @@ await fetchTrending()
           </NuxtLink>
         </li>
       </ul>
+      <NuxtLink
+        v-if="authStore.subscribedBoards.length > 8"
+        to="/boards"
+        class="block text-xs text-primary hover:underline mt-1 px-2 no-underline"
+      >
+        View all boards
+      </NuxtLink>
     </div>
 
     <!-- Trending boards -->
@@ -142,6 +214,13 @@ await fetchTrending()
           </NuxtLink>
         </li>
       </ul>
+    </div>
+
+    <!-- Footer links -->
+    <div class="border-t border-gray-200 pt-3">
+      <p class="text-[10px] text-gray-400 leading-relaxed">
+        Powered by TinyBoards &mdash; a self-hosted community platform.
+      </p>
     </div>
   </div>
 </template>

--- a/frontend/layouts/default.vue
+++ b/frontend/layouts/default.vue
@@ -2,7 +2,7 @@
   <div class="min-h-screen flex flex-col bg-gray-100">
     <LayoutAppHeader />
 
-    <div class="flex-1 flex gap-4 max-w-8xl mx-auto w-full">
+    <div class="flex-1 flex gap-6 lg:gap-8 max-w-8xl mx-auto w-full px-4 lg:px-8">
       <main class="flex-1 min-w-0">
         <slot />
       </main>

--- a/frontend/pages/all/[[sort]].vue
+++ b/frontend/pages/all/[[sort]].vue
@@ -31,14 +31,14 @@ await fetchPosts()
 <template>
   <div>
     <!-- Sort bar -->
-    <div class="max-w-5xl mx-auto px-4 pt-4">
+    <div class="pt-4">
       <div class="bg-white rounded-lg border border-gray-200 px-3 py-2 flex items-center justify-between mb-4">
         <CommonSortSelector v-model="sort" @update:model-value="setSort" />
         <CommonViewToggle />
       </div>
     </div>
 
-    <div class="max-w-5xl mx-auto px-4 pb-4">
+    <div class="pb-4">
       <CommonErrorDisplay v-if="error" :message="error.message" @retry="fetchPosts" />
 
       <PostList :posts="posts" :loading="loading" />

--- a/frontend/pages/home/[[sort]].vue
+++ b/frontend/pages/home/[[sort]].vue
@@ -34,7 +34,7 @@ await fetchPosts()
 <template>
   <div>
     <!-- Welcome banner for anonymous users -->
-    <div v-if="!authStore.isLoggedIn" class="max-w-5xl mx-auto px-4 pt-4">
+    <div v-if="!authStore.isLoggedIn" class="pt-4">
       <div class="bg-white rounded-lg border border-gray-200 overflow-hidden">
         <div class="h-24 bg-gradient-to-br from-primary to-primary-hover" />
         <div class="px-6 py-4 -mt-6">
@@ -69,7 +69,7 @@ await fetchPosts()
     </div>
 
     <!-- Sort bar -->
-    <div class="max-w-5xl mx-auto px-4 pt-4">
+    <div class="pt-4">
       <div class="bg-white rounded-lg border border-gray-200 px-3 py-2 flex items-center justify-between mb-4">
         <CommonSortSelector v-model="sort" @update:model-value="setSort" />
         <CommonViewToggle />
@@ -77,7 +77,7 @@ await fetchPosts()
     </div>
 
     <!-- Content area -->
-    <div class="max-w-5xl mx-auto px-4 pb-4">
+    <div class="pb-4">
       <CommonErrorDisplay v-if="error" :message="error.message" @retry="fetchPosts" />
 
       <PostList :posts="posts" :loading="loading" />


### PR DESCRIPTION
…rchy

- Widen main layout with more horizontal space (gap-6/8, px-4/8)
- Remove inner max-w-5xl constraints from home/all feed pages
- Increase sidebar width from 290px to 320px (w-80)
- Make sidebar sticky with viewport-aware max-height
- Add site stats widget (members, posts, comments, boards) to both sidebars
- Add "New Post" CTA button for logged-in users in sidebars
- Show up to 8 subscribed boards (was unlimited but typically few)
- Add "View all boards" link when user has 8+ subscriptions
- Strengthen post title weight to font-semibold for visual dominance
- Increase expanded post card padding (p-3 to p-3 lg:p-4)
- Fix vote widget column width to w-12 for consistent alignment
- Increase vote score font size to text-sm font-semibold
- Color board names with primary color for navigation prominence
- Increase card spacing from space-y-2 to space-y-3 in expanded mode
- Add footer text to sidebar for visual weight