### PR TITLE
fix(mobile): overhaul mobile UI/UX with proper responsive patterns

### DIFF
--- a/frontend/assets/css/main.css
+++ b/frontend/assets/css/main.css
@@ -393,6 +393,32 @@ img.emoji {
   animation: dropdown-enter 120ms ease-out;
 }
 
+/* Mobile sidebar drawer transitions */
+.sidebar-overlay-enter-active,
+.sidebar-overlay-leave-active {
+  transition: opacity 200ms ease;
+}
+.sidebar-overlay-enter-from,
+.sidebar-overlay-leave-to {
+  opacity: 0;
+}
+
+.sidebar-drawer-enter-active {
+  transition: transform 250ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+.sidebar-drawer-leave-active {
+  transition: transform 200ms ease-in;
+}
+.sidebar-drawer-enter-from,
+.sidebar-drawer-leave-to {
+  transform: translateX(-100%);
+}
+
+/* Mobile bottom nav safe area */
+.has-bottom-nav {
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+}
+
 /* Focus ring for keyboard navigation */
 :focus-visible {
   outline: 2px solid rgb(var(--color-primary) / 0.5);

--- a/frontend/components/comment/CommentActions.vue
+++ b/frontend/components/comment/CommentActions.vue
@@ -246,7 +246,7 @@ function openRemoveDialog (): void {
         </Teleport>
         <div
           v-if="showModMenu"
-          class="absolute left-0 top-full mt-1 w-44 bg-white rounded-lg border border-gray-200 shadow-lg z-50 py-1"
+          class="absolute right-0 sm:right-auto sm:left-0 top-full mt-1 w-44 bg-white rounded-lg border border-gray-200 shadow-lg z-50 py-1"
         >
           <div class="px-3 py-1.5 text-[10px] font-semibold text-gray-400 uppercase tracking-wider">
             Moderation

--- a/frontend/components/layout/AppHeader.vue
+++ b/frontend/components/layout/AppHeader.vue
@@ -31,7 +31,7 @@ async function handleLogout () {
 </script>
 
 <template>
-  <header class="bg-primary sticky top-0 z-40 shadow-md">
+  <header class="bg-primary sticky top-0 z-50 shadow-md">
     <div class="max-w-8xl mx-auto px-3 sm:px-6 h-14 flex items-center justify-between">
       <!-- Left: Logo + Nav -->
       <div class="flex items-center gap-4 min-w-0 flex-1">
@@ -135,7 +135,7 @@ async function handleLogout () {
             <!-- Backdrop (click to close) -->
             <div
               v-if="userMenuOpen"
-              class="fixed inset-0 z-40"
+              class="fixed inset-0 z-[60]"
               @click="closeUserMenu"
             />
 
@@ -150,7 +150,7 @@ async function handleLogout () {
             >
               <div
                 v-if="userMenuOpen"
-                class="absolute right-0 mt-1 w-48 bg-white rounded-lg shadow-lg ring-1 ring-black/5 z-50 py-1"
+                class="absolute right-0 mt-1 w-48 bg-white rounded-lg shadow-lg ring-1 ring-black/5 z-[70] py-1"
               >
                 <div class="px-3 py-2 border-b border-gray-100">
                   <p class="text-sm font-medium text-gray-900 truncate">{{ authStore.user?.displayName || authStore.user?.name }}</p>

--- a/frontend/components/layout/AppSidebar.vue
+++ b/frontend/components/layout/AppSidebar.vue
@@ -19,14 +19,26 @@ const currentSection = computed<SidebarSection>(() => {
 
   return 'home'
 })
+
+// Close sidebar on route change (mobile)
+watch(() => route.path, () => {
+  if (uiStore.sidebarOpen) {
+    uiStore.closeSidebar()
+  }
+})
+
+// Lock body scroll when sidebar is open on mobile
+watch(() => uiStore.sidebarOpen, (open) => {
+  if (import.meta.client) {
+    document.body.style.overflow = open ? 'hidden' : ''
+  }
+})
 </script>
 
 <template>
-  <aside
-    class="w-80 shrink-0"
-    :class="{ 'hidden lg:block': !uiStore.sidebarOpen }"
-  >
-    <div class="sticky top-4 space-y-0 max-h-[calc(100vh-5rem)] overflow-y-auto py-4 pr-1">
+  <!-- Desktop: static sidebar -->
+  <aside class="hidden lg:block w-80 shrink-0">
+    <div class="sticky top-20 space-y-0 max-h-[calc(100vh-6rem)] overflow-y-auto py-4 pr-1">
       <SidebarHomeSidebar v-if="currentSection === 'home'" />
       <SidebarAllSidebar v-else-if="currentSection === 'all'" />
       <SidebarBoardPageSidebar v-else-if="currentSection === 'board'" />
@@ -37,4 +49,92 @@ const currentSection = computed<SidebarSection>(() => {
       <SidebarHomeSidebar v-else />
     </div>
   </aside>
+
+  <!-- Mobile: slide-out drawer -->
+  <Teleport to="body">
+    <Transition name="sidebar-overlay">
+      <div
+        v-if="uiStore.sidebarOpen"
+        class="fixed inset-0 bg-black/40 z-50 lg:hidden"
+        @click="uiStore.closeSidebar()"
+      />
+    </Transition>
+
+    <Transition name="sidebar-drawer">
+      <aside
+        v-if="uiStore.sidebarOpen"
+        class="fixed top-0 left-0 bottom-0 w-[min(320px,85vw)] bg-white z-50 lg:hidden shadow-xl overflow-y-auto overscroll-contain"
+      >
+        <!-- Drawer header -->
+        <div class="sticky top-0 bg-primary text-white px-4 py-3 flex items-center justify-between z-10">
+          <span class="font-semibold text-sm">Menu</span>
+          <button
+            class="p-1 rounded hover:bg-white/20 transition-colors"
+            aria-label="Close menu"
+            @click="uiStore.closeSidebar()"
+          >
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <!-- Mobile nav links -->
+        <nav class="px-3 py-3 border-b border-gray-200">
+          <NuxtLink
+            to="/home"
+            class="flex items-center gap-3 px-3 py-2.5 text-sm font-medium rounded-lg no-underline transition-colors"
+            :class="currentSection === 'home' ? 'bg-primary/10 text-primary' : 'text-gray-700 hover:bg-gray-100'"
+          >
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+            </svg>
+            Home
+          </NuxtLink>
+          <NuxtLink
+            to="/all"
+            class="flex items-center gap-3 px-3 py-2.5 text-sm font-medium rounded-lg no-underline transition-colors"
+            :class="currentSection === 'all' ? 'bg-primary/10 text-primary' : 'text-gray-700 hover:bg-gray-100'"
+          >
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            All
+          </NuxtLink>
+          <NuxtLink
+            to="/boards"
+            class="flex items-center gap-3 px-3 py-2.5 text-sm font-medium rounded-lg no-underline transition-colors"
+            :class="currentSection === 'boards' ? 'bg-primary/10 text-primary' : 'text-gray-700 hover:bg-gray-100'"
+          >
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z" />
+            </svg>
+            Boards
+          </NuxtLink>
+          <NuxtLink
+            to="/members"
+            class="flex items-center gap-3 px-3 py-2.5 text-sm font-medium rounded-lg no-underline transition-colors"
+            :class="currentSection === 'members' ? 'bg-primary/10 text-primary' : 'text-gray-700 hover:bg-gray-100'"
+          >
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z" />
+            </svg>
+            Members
+          </NuxtLink>
+        </nav>
+
+        <!-- Context sidebar content -->
+        <div class="p-3">
+          <SidebarHomeSidebar v-if="currentSection === 'home'" />
+          <SidebarAllSidebar v-else-if="currentSection === 'all'" />
+          <SidebarBoardPageSidebar v-else-if="currentSection === 'board'" />
+          <SidebarUserProfileSidebar v-else-if="currentSection === 'user'" />
+          <SidebarBoardsDirectorySidebar v-else-if="currentSection === 'boards'" />
+          <SidebarSearchSidebar v-else-if="currentSection === 'search'" />
+          <SidebarMembersSidebar v-else-if="currentSection === 'members'" />
+          <SidebarHomeSidebar v-else />
+        </div>
+      </aside>
+    </Transition>
+  </Teleport>
 </template>

--- a/frontend/components/layout/MobileBottomNav.vue
+++ b/frontend/components/layout/MobileBottomNav.vue
@@ -1,0 +1,108 @@
+<script setup lang="ts">
+import { useAuthStore } from '~/stores/auth'
+
+const route = useRoute()
+const authStore = useAuthStore()
+
+function isActive (path: string): boolean {
+  if (path === '/home') return route.path === '/home' || route.path === '/'
+  return route.path.startsWith(path)
+}
+</script>
+
+<template>
+  <nav class="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 z-40 safe-bottom">
+    <div class="flex items-stretch justify-around h-14">
+      <NuxtLink
+        to="/home"
+        class="flex flex-col items-center justify-center flex-1 gap-0.5 no-underline transition-colors"
+        :class="isActive('/home') ? 'text-primary' : 'text-gray-400'"
+      >
+        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+        </svg>
+        <span class="text-[10px] font-medium leading-none">Home</span>
+      </NuxtLink>
+
+      <NuxtLink
+        to="/all"
+        class="flex flex-col items-center justify-center flex-1 gap-0.5 no-underline transition-colors"
+        :class="isActive('/all') ? 'text-primary' : 'text-gray-400'"
+      >
+        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+        </svg>
+        <span class="text-[10px] font-medium leading-none">All</span>
+      </NuxtLink>
+
+      <NuxtLink
+        v-if="authStore.isLoggedIn"
+        to="/submit"
+        class="flex flex-col items-center justify-center flex-1 gap-0.5 no-underline transition-colors"
+        :class="isActive('/submit') ? 'text-primary' : 'text-gray-400'"
+      >
+        <div class="w-8 h-8 rounded-full bg-primary flex items-center justify-center -mt-1">
+          <svg class="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+          </svg>
+        </div>
+        <span class="text-[10px] font-medium leading-none">Post</span>
+      </NuxtLink>
+      <NuxtLink
+        v-else
+        to="/boards"
+        class="flex flex-col items-center justify-center flex-1 gap-0.5 no-underline transition-colors"
+        :class="isActive('/boards') ? 'text-primary' : 'text-gray-400'"
+      >
+        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z" />
+        </svg>
+        <span class="text-[10px] font-medium leading-none">Boards</span>
+      </NuxtLink>
+
+      <NuxtLink
+        to="/search"
+        class="flex flex-col items-center justify-center flex-1 gap-0.5 no-underline transition-colors"
+        :class="isActive('/search') ? 'text-primary' : 'text-gray-400'"
+      >
+        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+        </svg>
+        <span class="text-[10px] font-medium leading-none">Search</span>
+      </NuxtLink>
+
+      <NuxtLink
+        v-if="authStore.isLoggedIn"
+        to="/inbox"
+        class="flex flex-col items-center justify-center flex-1 gap-0.5 no-underline transition-colors relative"
+        :class="isActive('/inbox') ? 'text-primary' : 'text-gray-400'"
+      >
+        <div class="relative">
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
+          </svg>
+          <span
+            v-if="authStore.unreadNotificationCount > 0"
+            class="absolute -top-1 -right-1.5 flex items-center justify-center min-w-[14px] h-3.5 px-0.5 rounded-full bg-red-500 text-white text-[9px] font-bold leading-none"
+          >
+            {{ authStore.unreadNotificationCount > 99 ? '99+' : authStore.unreadNotificationCount }}
+          </span>
+        </div>
+        <span class="text-[10px] font-medium leading-none">Inbox</span>
+      </NuxtLink>
+      <NuxtLink
+        v-else
+        to="/login"
+        class="flex flex-col items-center justify-center flex-1 gap-0.5 no-underline transition-colors"
+        :class="isActive('/login') ? 'text-primary' : 'text-gray-400'"
+      >
+        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+        </svg>
+        <span class="text-[10px] font-medium leading-none">Log in</span>
+      </NuxtLink>
+    </div>
+    <!-- iOS safe area padding -->
+    <div class="h-[env(safe-area-inset-bottom,0px)] bg-white" />
+  </nav>
+</template>

--- a/frontend/components/post/PostActions.vue
+++ b/frontend/components/post/PostActions.vue
@@ -70,12 +70,15 @@ async function vote (score: number): Promise<void> {
 
 <template>
   <div
-    class="flex items-center gap-0.5 text-sm"
-    :class="layout === 'vertical' ? 'flex-col' : 'flex-row'"
+    class="flex items-center text-sm"
+    :class="layout === 'vertical' ? 'flex-col gap-0.5' : 'flex-row gap-1'"
   >
     <button
-      class="upvote p-1.5 rounded-md hover:bg-primary/10 flex items-center justify-center transition-colors"
-      :class="localMyVote === 1 ? 'upvoted text-primary' : 'text-gray-400 hover:text-primary'"
+      class="upvote rounded-md hover:bg-primary/10 flex items-center justify-center transition-colors"
+      :class="[
+        localMyVote === 1 ? 'upvoted text-primary' : 'text-gray-400 hover:text-primary',
+        layout === 'vertical' ? 'p-1.5' : 'p-1.5 sm:p-1'
+      ]"
       aria-label="Upvote"
       @click="vote(1)"
     >
@@ -97,8 +100,11 @@ async function vote (score: number): Promise<void> {
 
     <button
       v-if="siteStore.enableDownvotes"
-      class="downvote p-1.5 rounded-md hover:bg-secondary/10 flex items-center justify-center transition-colors"
-      :class="localMyVote === -1 ? 'downvoted text-secondary' : 'text-gray-400 hover:text-secondary'"
+      class="downvote rounded-md hover:bg-secondary/10 flex items-center justify-center transition-colors"
+      :class="[
+        localMyVote === -1 ? 'downvoted text-secondary' : 'text-gray-400 hover:text-secondary',
+        layout === 'vertical' ? 'p-1.5' : 'p-1.5 sm:p-1'
+      ]"
       aria-label="Downvote"
       @click="vote(-1)"
     >

--- a/frontend/components/post/PostCard.vue
+++ b/frontend/components/post/PostCard.vue
@@ -167,12 +167,17 @@ const hasLinkPreview = computed(() => {
 
     <!-- Expanded mode -->
     <template v-else>
-      <div class="flex">
-        <!-- Vote column (only for non-thread posts) -->
-        <PostActions v-if="!isThread" :post="post" layout="vertical" class="w-12 shrink-0 px-2 py-3 border-r border-gray-100 bg-gray-50/50 rounded-l-lg" />
+      <div class="flex sm:flex-row flex-col">
+        <!-- Vote column: hidden on mobile, visible on sm+ -->
+        <PostActions
+          v-if="!isThread"
+          :post="post"
+          layout="vertical"
+          class="hidden sm:flex w-12 shrink-0 px-2 py-3 border-r border-gray-100 bg-gray-50/50 rounded-l-lg"
+        />
 
         <!-- Content -->
-        <div class="flex-1 min-w-0 p-3 lg:p-4">
+        <div class="flex-1 min-w-0 p-3 sm:p-3 lg:p-4">
           <!-- Author line with avatar -->
           <div class="flex items-center gap-2 mb-1.5">
             <CommonAvatar
@@ -239,7 +244,7 @@ const hasLinkPreview = computed(() => {
 
           <!-- Video embed (YouTube or direct video) -->
           <ClientOnly>
-            <div v-if="isYouTubeEmbed" class="mt-2 rounded-lg overflow-hidden aspect-video max-w-lg">
+            <div v-if="isYouTubeEmbed" class="mt-2 rounded-lg overflow-hidden aspect-video max-w-full sm:max-w-lg">
               <iframe
                 :src="post.embedVideoUrl!"
                 class="w-full h-full"
@@ -249,7 +254,7 @@ const hasLinkPreview = computed(() => {
                 loading="lazy"
               />
             </div>
-            <div v-else-if="isDirectVideo" class="mt-2 max-w-lg">
+            <div v-else-if="isDirectVideo" class="mt-2 max-w-full sm:max-w-lg">
               <video
                 :src="post.embedVideoUrl!"
                 class="w-full rounded-lg"
@@ -264,12 +269,12 @@ const hasLinkPreview = computed(() => {
             v-if="!post.embedVideoUrl && post.thumbnailUrl"
             :src="post.thumbnailUrl"
             :alt="post.title"
-            class="mt-2 max-w-sm max-h-64 rounded-lg object-cover"
+            class="mt-2 max-w-full sm:max-w-sm max-h-64 rounded-lg object-cover"
             loading="lazy"
           />
 
           <!-- Post video (uploaded video file) -->
-          <div v-if="isImageVideo" class="mt-2 max-w-lg">
+          <div v-if="isImageVideo" class="mt-2 max-w-full sm:max-w-lg">
             <video
               :src="post.image!"
               class="w-full rounded-lg"
@@ -284,7 +289,7 @@ const hasLinkPreview = computed(() => {
             v-if="post.image && !post.thumbnailUrl && !isImageVideo"
             :src="post.image"
             :alt="post.altText || post.title"
-            class="mt-2 max-w-sm max-h-64 rounded-lg object-cover"
+            class="mt-2 max-w-full sm:max-w-sm max-h-64 rounded-lg object-cover"
             loading="lazy"
           />
 
@@ -294,7 +299,7 @@ const hasLinkPreview = computed(() => {
             :href="post.url"
             target="_blank"
             rel="noopener noreferrer"
-            class="mt-2 block border border-gray-200 rounded-lg overflow-hidden hover:border-gray-300 transition-colors no-underline max-w-lg"
+            class="mt-2 block border border-gray-200 rounded-lg overflow-hidden hover:border-gray-300 transition-colors no-underline max-w-full sm:max-w-lg"
           >
             <div class="px-3 py-2">
               <p v-if="post.embedTitle" class="text-sm font-medium text-gray-800 line-clamp-1">
@@ -326,8 +331,16 @@ const hasLinkPreview = computed(() => {
             </span>
           </div>
 
-          <!-- Action bar -->
+          <!-- Action bar: votes (mobile) + comments + save + board -->
           <div class="mt-2 flex items-center gap-3 text-xs text-gray-500">
+            <!-- Mobile inline votes -->
+            <PostActions
+              v-if="!isThread"
+              :post="post"
+              layout="horizontal"
+              class="sm:hidden"
+            />
+
             <NuxtLink
               :to="postUrl(post)"
               class="inline-flex items-center gap-1 no-underline text-gray-500 hover:text-gray-700 transition-colors"

--- a/frontend/components/post/PostDetail.vue
+++ b/frontend/components/post/PostDetail.vue
@@ -121,9 +121,10 @@ function onClickOutsideMenu (e: Event): void {
 </script>
 
 <template>
-  <article class="bg-white border border-gray-200 rounded p-4">
-    <div class="flex gap-3">
-      <PostActions :post="post" layout="vertical" />
+  <article class="bg-white border border-gray-200 rounded p-3 sm:p-4">
+    <div class="flex flex-col sm:flex-row gap-3">
+      <!-- Vote column: hidden on mobile, shown on sm+ -->
+      <PostActions :post="post" layout="vertical" class="hidden sm:flex" />
 
       <div class="flex-1 min-w-0">
         <h1 class="text-xl font-bold text-gray-900 leading-snug">
@@ -208,6 +209,11 @@ function onClickOutsideMenu (e: Event): void {
           {{ post.body }}
         </div>
 
+        <!-- Mobile inline votes -->
+        <div class="sm:hidden mt-3">
+          <PostActions :post="post" layout="horizontal" />
+        </div>
+
         <!-- Action bar: unified user + mod actions -->
         <div class="flex items-center gap-1 mt-3 text-xs text-gray-500 flex-wrap">
           <!-- Comments count -->
@@ -280,7 +286,7 @@ function onClickOutsideMenu (e: Event): void {
                 </Teleport>
                 <div
                   v-if="showMoreMenu"
-                  class="absolute left-0 top-full mt-1 w-48 bg-white rounded-lg border border-gray-200 shadow-lg z-50 py-1"
+                  class="absolute right-0 sm:right-auto sm:left-0 top-full mt-1 w-48 bg-white rounded-lg border border-gray-200 shadow-lg z-50 py-1"
                 >
                   <div class="px-3 py-1.5 text-[10px] font-semibold text-gray-400 uppercase tracking-wider">
                     Moderation

--- a/frontend/layouts/admin.vue
+++ b/frontend/layouts/admin.vue
@@ -27,22 +27,29 @@ const mobileNavOpen = ref(false)
     <LayoutAppHeader />
 
     <!-- Mobile admin nav toggle -->
-    <div class="md:hidden bg-white border-b border-gray-200 px-4 py-2">
+    <div class="lg:hidden bg-white border-b border-gray-200 px-4 py-2">
       <button
-        class="flex items-center gap-2 text-sm font-medium text-gray-700"
+        class="flex items-center gap-2 text-sm font-medium text-gray-700 w-full"
         @click="mobileNavOpen = !mobileNavOpen"
       >
         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
         </svg>
         Admin Menu
+        <svg
+          class="w-4 h-4 ml-auto transition-transform"
+          :class="{ 'rotate-180': mobileNavOpen }"
+          fill="none" stroke="currentColor" viewBox="0 0 24 24"
+        >
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+        </svg>
       </button>
-      <nav v-if="mobileNavOpen" class="mt-2 pb-1">
+      <nav v-if="mobileNavOpen" class="mt-2 pb-1 max-h-[60vh] overflow-y-auto">
         <NuxtLink
           v-for="item in adminNav"
           :key="item.to"
           :to="item.to"
-          class="block px-3 py-2 text-sm rounded no-underline text-gray-700 hover:bg-gray-50"
+          class="block px-3 py-2.5 text-sm rounded no-underline text-gray-700 hover:bg-gray-50"
           active-class="bg-primary/5 text-primary font-medium"
           @click="mobileNavOpen = false"
         >
@@ -51,10 +58,10 @@ const mobileNavOpen = ref(false)
       </nav>
     </div>
 
-    <div class="flex-1 max-w-6xl mx-auto w-full px-4 py-6">
+    <div class="flex-1 max-w-6xl mx-auto w-full px-3 sm:px-4 py-4 sm:py-6 pb-20 lg:pb-6">
       <div class="flex gap-6">
         <!-- Admin sidebar nav (desktop) -->
-        <nav class="w-52 shrink-0 hidden md:block">
+        <nav class="w-52 shrink-0 hidden lg:block">
           <div class="bg-white rounded-lg border border-gray-200 overflow-hidden sticky top-20">
             <div class="px-4 py-3 bg-primary text-white">
               <h2 class="font-semibold text-sm">Admin Panel</h2>
@@ -75,13 +82,14 @@ const mobileNavOpen = ref(false)
 
         <!-- Content area -->
         <main class="flex-1 min-w-0">
-          <div class="bg-white rounded-lg border border-gray-200 p-6">
+          <div class="bg-white rounded-lg border border-gray-200 p-4 sm:p-6">
             <slot />
           </div>
         </main>
       </div>
     </div>
 
-    <LayoutAppFooter />
+    <LayoutAppFooter class="hidden lg:block" />
+    <LayoutMobileBottomNav class="lg:hidden" />
   </div>
 </template>

--- a/frontend/layouts/default.vue
+++ b/frontend/layouts/default.vue
@@ -2,13 +2,14 @@
   <div class="min-h-screen flex flex-col bg-gray-100">
     <LayoutAppHeader />
 
-    <div class="flex-1 flex gap-6 lg:gap-8 max-w-8xl mx-auto w-full px-4 lg:px-8">
-      <main class="flex-1 min-w-0">
+    <div class="flex-1 flex gap-6 lg:gap-8 max-w-8xl mx-auto w-full px-3 sm:px-4 lg:px-8">
+      <main class="flex-1 min-w-0 pb-20 lg:pb-0">
         <slot />
       </main>
       <LayoutAppSidebar />
     </div>
 
-    <LayoutAppFooter />
+    <LayoutAppFooter class="hidden lg:block" />
+    <LayoutMobileBottomNav class="lg:hidden" />
   </div>
 </template>

--- a/frontend/layouts/settings.vue
+++ b/frontend/layouts/settings.vue
@@ -16,22 +16,29 @@ const mobileNavOpen = ref(false)
     <LayoutAppHeader />
 
     <!-- Mobile settings nav toggle -->
-    <div class="md:hidden bg-white border-b border-gray-200 px-4 py-2">
+    <div class="lg:hidden bg-white border-b border-gray-200 px-4 py-2">
       <button
-        class="flex items-center gap-2 text-sm font-medium text-gray-700"
+        class="flex items-center gap-2 text-sm font-medium text-gray-700 w-full"
         @click="mobileNavOpen = !mobileNavOpen"
       >
         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
         </svg>
         Settings Menu
+        <svg
+          class="w-4 h-4 ml-auto transition-transform"
+          :class="{ 'rotate-180': mobileNavOpen }"
+          fill="none" stroke="currentColor" viewBox="0 0 24 24"
+        >
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+        </svg>
       </button>
       <nav v-if="mobileNavOpen" class="mt-2 pb-1">
         <NuxtLink
           v-for="item in settingsNav"
           :key="item.to"
           :to="item.to"
-          class="block px-3 py-2 text-sm rounded no-underline text-gray-700 hover:bg-gray-50"
+          class="block px-3 py-2.5 text-sm rounded no-underline text-gray-700 hover:bg-gray-50"
           active-class="bg-primary/5 text-primary font-medium"
           @click="mobileNavOpen = false"
         >
@@ -40,11 +47,11 @@ const mobileNavOpen = ref(false)
       </nav>
     </div>
 
-    <div class="flex-1 max-w-5xl mx-auto w-full px-4 py-6">
+    <div class="flex-1 max-w-5xl mx-auto w-full px-3 sm:px-4 py-4 sm:py-6 pb-20 lg:pb-6">
       <div class="flex gap-6">
         <!-- Settings sidebar nav (desktop) -->
-        <nav class="w-52 shrink-0 hidden md:block">
-          <div class="bg-white rounded-lg border border-gray-200 overflow-hidden">
+        <nav class="w-52 shrink-0 hidden lg:block">
+          <div class="bg-white rounded-lg border border-gray-200 overflow-hidden sticky top-20">
             <div class="px-4 py-3 bg-primary text-white">
               <h2 class="font-semibold text-sm">Settings</h2>
             </div>
@@ -64,13 +71,14 @@ const mobileNavOpen = ref(false)
 
         <!-- Content area -->
         <main class="flex-1 min-w-0">
-          <div class="bg-white rounded-lg border border-gray-200 p-6">
+          <div class="bg-white rounded-lg border border-gray-200 p-4 sm:p-6">
             <slot />
           </div>
         </main>
       </div>
     </div>
 
-    <LayoutAppFooter />
+    <LayoutAppFooter class="hidden lg:block" />
+    <LayoutMobileBottomNav class="lg:hidden" />
   </div>
 </template>

--- a/frontend/stores/ui.ts
+++ b/frontend/stores/ui.ts
@@ -42,6 +42,10 @@ export const useUIStore = defineStore('ui', () => {
     sidebarOpen.value = !sidebarOpen.value
   }
 
+  function closeSidebar (): void {
+    sidebarOpen.value = false
+  }
+
   function setPostViewMode (mode: PostViewMode): void {
     postViewMode.value = mode
   }
@@ -79,6 +83,7 @@ export const useUIStore = defineStore('ui', () => {
     toasts,
     setTheme,
     toggleSidebar,
+    closeSidebar,
     setPostViewMode,
     openModal,
     closeModal,


### PR DESCRIPTION
- Sidebar: convert from inline to slide-out drawer on mobile with overlay backdrop, body scroll lock, close on route change, and smooth animations
- PostCard: hide vertical vote column on mobile, show inline horizontal votes in action bar instead; fix media max-width for small screens
- PostDetail: same mobile vote pattern (hide sidebar votes, show inline)
- PostActions: responsive padding for touch targets on mobile
- Bottom nav: add persistent mobile bottom navigation with Home, All, Post/Boards, Search, and Inbox/Login tabs with notification badge
- Default layout: add bottom padding for mobile nav, hide footer on mobile
- Settings/Admin layouts: change sidebar breakpoint from md to lg for consistency, add mobile bottom nav, improve mobile padding
- Header: bump z-index above sidebar drawer, fix dropdown z-layering
- Dropdowns: use right-0 on mobile to prevent overflow off-screen edge
- CSS: add sidebar drawer slide/fade transitions, safe area support
- UI store: add closeSidebar method for explicit close actions