### PR TITLE
fix(auth): prevent session expiration from concurrent token refresh r…

### DIFF
--- a/frontend/composables/useGraphQL.ts
+++ b/frontend/composables/useGraphQL.ts
@@ -1,6 +1,7 @@
 import { ref } from 'vue'
 import type { Ref } from 'vue'
 import type { ApiResponse, ApiError } from '~/types/api'
+import { useAuthStore } from '~/stores/auth'
 
 interface GraphQLRequestOptions {
   variables?: Record<string, unknown>
@@ -57,6 +58,17 @@ export function useGraphQL<T = unknown> (): UseGraphQLReturn<T> {
       if (response.errors && response.errors.length > 0) {
         error.value = response.errors[0]
         data.value = null
+
+        // If the BFF returned an auth error, the refresh already failed server-side
+        // and cookies were cleared. Sync the client-side store so the UI reflects
+        // the logged-out state instead of showing stale auth.
+        if (import.meta.client && isAuthError(response.errors)) {
+          const authStore = useAuthStore()
+          if (authStore.isLoggedIn) {
+            authStore.clearUser()
+          }
+        }
+
         return null
       }
 
@@ -81,4 +93,13 @@ export function useGraphQL<T = unknown> (): UseGraphQLReturn<T> {
  */
 export function useGraphQLMutation<T = unknown> (): UseGraphQLReturn<T> {
   return useGraphQL<T>()
+}
+
+function isAuthError (errors: ApiError[]): boolean {
+  return errors.some(
+    err =>
+      err.message?.toLowerCase().includes('unauthorized') ||
+      err.message?.toLowerCase().includes('not authenticated') ||
+      err.extensions?.code === 'UNAUTHENTICATED',
+  )
 }

--- a/frontend/middleware/02.auth.global.ts
+++ b/frontend/middleware/02.auth.global.ts
@@ -24,6 +24,10 @@ export default defineNuxtRouteMiddleware(async () => {
       if (authContext.subscribedBoards) {
         authStore.setSubscribedBoards(authContext.subscribedBoards)
       }
+
+      if (typeof authContext.unreadNotificationsCount === 'number') {
+        authStore.setUnreadNotificationCount(authContext.unreadNotificationsCount)
+      }
     }
   }
 })

--- a/frontend/server/api/graphql-upload.ts
+++ b/frontend/server/api/graphql-upload.ts
@@ -1,4 +1,5 @@
 import { defineEventHandler, getCookie, setCookie, createError, getHeader, readMultipartFormData } from 'h3'
+import { withRefreshLock } from '~/server/utils/refreshLock'
 
 /**
  * BFF proxy for GraphQL file uploads (multipart/form-data).
@@ -33,51 +34,20 @@ export default defineEventHandler(async (event) => {
   }
 
   // Reconstruct multipart form data for the backend
-  const formData = new FormData()
-
-  for (const part of parts) {
-    const fieldName = part.name ?? ''
-
-    if (part.filename) {
-      // File field — create a Blob with proper content type
-      const blob = new Blob([part.data], { type: part.type || 'application/octet-stream' })
-      formData.append(fieldName, blob, part.filename)
-    } else {
-      // Text field (operations, map, etc.)
-      formData.append(fieldName, part.data.toString('utf-8'))
-    }
-  }
+  const formData = buildFormData(parts)
 
   const accessToken = getCookie(event, 'tb_access')
 
-  const headers: Record<string, string> = {}
-  if (accessToken) {
-    headers.Cookie = `tb_access=${accessToken}`
-  }
-
   try {
-    const response = await fetch(gqlEndpoint, {
-      method: 'POST',
-      headers,
-      body: formData,
-    })
+    const { status, data } = await forwardUpload(gqlEndpoint, formData, accessToken)
 
-    const data = await response.json()
-
-    if (response.status === 401 || hasAuthError(data)) {
-      const refreshed = await attemptTokenRefresh(event, config.internalApiHost)
-      if (refreshed) {
-        const newAccessToken = getCookie(event, 'tb_access')
-        const retryHeaders: Record<string, string> = {}
-        if (newAccessToken) {
-          retryHeaders.Cookie = `tb_access=${newAccessToken}`
-        }
-        const retryResponse = await fetch(gqlEndpoint, {
-          method: 'POST',
-          headers: retryHeaders,
-          body: formData,
-        })
-        return await retryResponse.json()
+    if (status === 401 || hasAuthError(data as { errors?: Array<{ message: string; extensions?: Record<string, unknown> }> })) {
+      const newAccessToken = await attemptTokenRefresh(event, config.internalApiHost)
+      if (newAccessToken) {
+        // Rebuild form data for retry (original may have been consumed)
+        const retryFormData = buildFormData(parts)
+        const retry = await forwardUpload(gqlEndpoint, retryFormData, newAccessToken)
+        return retry.data
       }
 
       clearAuthCookies(event)
@@ -92,6 +62,40 @@ export default defineEventHandler(async (event) => {
   }
 })
 
+function buildFormData (parts: { name?: string; filename?: string; data: Buffer; type?: string }[]): FormData {
+  const formData = new FormData()
+  for (const part of parts) {
+    const fieldName = part.name ?? ''
+    if (part.filename) {
+      const blob = new Blob([new Uint8Array(part.data)], { type: part.type || 'application/octet-stream' })
+      formData.append(fieldName, blob, part.filename)
+    } else {
+      formData.append(fieldName, part.data.toString('utf-8'))
+    }
+  }
+  return formData
+}
+
+async function forwardUpload (
+  endpoint: string,
+  formData: FormData,
+  accessToken?: string | null,
+): Promise<{ status: number; data: unknown }> {
+  const headers: Record<string, string> = {}
+  if (accessToken) {
+    headers.Cookie = `tb_access=${accessToken}`
+  }
+
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers,
+    body: formData,
+  })
+
+  const data = await response.json()
+  return { status: response.status, data }
+}
+
 function hasAuthError (response: { errors?: Array<{ message: string; extensions?: Record<string, unknown> }> }): boolean {
   if (!response.errors) { return false }
   return response.errors.some(
@@ -105,34 +109,43 @@ function hasAuthError (response: { errors?: Array<{ message: string; extensions?
 async function attemptTokenRefresh (
   event: Parameters<Parameters<typeof defineEventHandler>[0]>[0],
   internalApiHost: string,
-): Promise<boolean> {
+): Promise<string | null> {
   const refreshToken = getCookie(event, 'tb_refresh')
   const accessToken = getCookie(event, 'tb_access')
-  if (!refreshToken) { return false }
+  if (!refreshToken) { return null }
 
   const refreshEndpoint = `${internalApiHost}/api/v2/auth/refresh`
 
-  try {
-    const response = await fetch(refreshEndpoint, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Requested-With': 'XMLHttpRequest',
-        Cookie: `tb_access=${accessToken ?? ''}; tb_refresh=${refreshToken}`,
-      },
-    })
+  return withRefreshLock(async () => {
+    try {
+      const response = await fetch(refreshEndpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Requested-With': 'XMLHttpRequest',
+          Cookie: `tb_access=${accessToken ?? ''}; tb_refresh=${refreshToken}`,
+        },
+      })
 
-    if (!response.ok) { return false }
+      if (!response.ok) { return null }
 
-    const setCookieHeaders = response.headers.getSetCookie?.() ?? []
-    for (const cookieHeader of setCookieHeaders) {
-      event.node.res.appendHeader('Set-Cookie', cookieHeader)
+      const setCookieHeaders = response.headers.getSetCookie?.() ?? []
+      for (const cookieHeader of setCookieHeaders) {
+        event.node.res.appendHeader('Set-Cookie', cookieHeader)
+      }
+
+      for (const header of setCookieHeaders) {
+        const match = header.match(/tb_access=([^;]+)/)
+        if (match) {
+          return match[1]
+        }
+      }
+
+      return null
+    } catch {
+      return null
     }
-
-    return setCookieHeaders.length > 0
-  } catch {
-    return false
-  }
+  })
 }
 
 function clearAuthCookies (

--- a/frontend/server/api/graphql.ts
+++ b/frontend/server/api/graphql.ts
@@ -1,4 +1,5 @@
 import { defineEventHandler, readBody, getCookie, setCookie, createError, getHeader } from 'h3'
+import { withRefreshLock } from '~/server/utils/refreshLock'
 
 interface GraphQLRequest {
   query: string
@@ -15,7 +16,7 @@ interface GraphQLResponse {
  * BFF proxy for all GraphQL traffic.
  * - Reads httpOnly auth cookie server-side (tb_access)
  * - Forwards requests to the backend GraphQL endpoint
- * - Handles 401 → refresh → retry flow
+ * - Handles 401 → refresh → retry flow (with deduplication)
  * - Validates X-Requested-With header (CSRF protection)
  *
  * Auth mutations (login/register) are no longer handled here.
@@ -49,10 +50,9 @@ export default defineEventHandler(async (event) => {
 
   // Check for authentication errors (HTTP 401 or GraphQL-level auth errors)
   if (result.httpStatus === 401 || hasAuthError(result.data)) {
-    const refreshed = await attemptTokenRefresh(event, config.internalApiHost)
-    if (refreshed) {
-      // Retry original request with new token
-      const newAccessToken = getCookie(event, 'tb_access')
+    const newAccessToken = await attemptTokenRefresh(event, config.internalApiHost)
+    if (newAccessToken) {
+      // Retry original request with the new token
       const retry = await forwardGraphQLRequest(gqlEndpoint, body, newAccessToken)
       return retry.data
     }
@@ -72,7 +72,7 @@ interface ForwardResult {
 async function forwardGraphQLRequest (
   endpoint: string,
   body: GraphQLRequest,
-  accessToken?: string,
+  accessToken?: string | null,
 ): Promise<ForwardResult> {
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
@@ -112,43 +112,58 @@ function hasAuthError (response: GraphQLResponse): boolean {
   )
 }
 
+/**
+ * Attempt to refresh the access token, using a lock to prevent concurrent
+ * refreshes from invalidating each other's tokens (thundering herd).
+ * Returns the new access token string on success, or null on failure.
+ */
 async function attemptTokenRefresh (
   event: Parameters<Parameters<typeof defineEventHandler>[0]>[0],
   internalApiHost: string,
-): Promise<boolean> {
+): Promise<string | null> {
   const refreshToken = getCookie(event, 'tb_refresh')
   const accessToken = getCookie(event, 'tb_access')
-  if (!refreshToken) { return false }
+  if (!refreshToken) { return null }
 
-  // Call the backend refresh endpoint directly with both cookies.
   const refreshEndpoint = `${internalApiHost}/api/v2/auth/refresh`
 
-  try {
-    const response = await fetch(refreshEndpoint, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Requested-With': 'XMLHttpRequest',
-        Cookie: `tb_access=${accessToken ?? ''}; tb_refresh=${refreshToken}`,
-      },
-    })
+  const newAccessToken = await withRefreshLock(async () => {
+    try {
+      const response = await fetch(refreshEndpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Requested-With': 'XMLHttpRequest',
+          Cookie: `tb_access=${accessToken ?? ''}; tb_refresh=${refreshToken}`,
+        },
+      })
 
-    if (!response.ok) {
-      return false
+      if (!response.ok) {
+        return null
+      }
+
+      // Forward Set-Cookie headers from the backend response to the client
+      const setCookieHeaders = response.headers.getSetCookie?.() ?? []
+      for (const cookieHeader of setCookieHeaders) {
+        event.node.res.appendHeader('Set-Cookie', cookieHeader)
+      }
+
+      // Extract the new access token from Set-Cookie headers so we can use
+      // it immediately for the retry (the h3 cookie jar won't reflect it yet)
+      for (const header of setCookieHeaders) {
+        const match = header.match(/tb_access=([^;]+)/)
+        if (match) {
+          return match[1]
+        }
+      }
+
+      return null
+    } catch {
+      return null
     }
+  })
 
-    // Forward Set-Cookie headers from the backend response to the client
-    const setCookieHeaders = response.headers.getSetCookie?.() ?? []
-    for (const cookieHeader of setCookieHeaders) {
-      event.node.res.appendHeader('Set-Cookie', cookieHeader)
-    }
-
-    return setCookieHeaders.length > 0
-  } catch {
-    // Refresh failed — caller will handle cleanup
-  }
-
-  return false
+  return newAccessToken
 }
 
 function clearAuthCookies (

--- a/frontend/server/middleware/auth.ts
+++ b/frontend/server/middleware/auth.ts
@@ -1,4 +1,5 @@
-import { defineEventHandler, getCookie, setCookie, getHeader } from 'h3'
+import { defineEventHandler, getCookie, setCookie } from 'h3'
+import { withRefreshLock } from '~/server/utils/refreshLock'
 
 const ME_QUERY = `
   query Me {
@@ -37,7 +38,8 @@ const SUBSCRIBED_BOARDS_QUERY = `
  * route middleware can populate the Pinia store without a second round-trip.
  *
  * If the access token is expired but a valid refresh token exists, this
- * middleware will refresh the session automatically.
+ * middleware will refresh the session automatically using the shared refresh
+ * lock to avoid thundering herd issues.
  */
 export default defineEventHandler(async (event) => {
   const accessToken = getCookie(event, 'tb_access')
@@ -125,6 +127,10 @@ async function fetchUserData (
   }
 }
 
+/**
+ * Attempt to refresh the access token using the shared lock to prevent
+ * concurrent refresh attempts from invalidating each other.
+ */
 async function attemptTokenRefresh (
   event: Parameters<Parameters<typeof defineEventHandler>[0]>[0],
   internalApiHost: string,
@@ -133,36 +139,38 @@ async function attemptTokenRefresh (
 ): Promise<string | null> {
   const refreshEndpoint = `${internalApiHost}/api/v2/auth/refresh`
 
-  try {
-    const response = await fetch(refreshEndpoint, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Requested-With': 'XMLHttpRequest',
-        Cookie: `tb_access=${accessToken ?? ''}; tb_refresh=${refreshToken}`,
-      },
-    })
+  return withRefreshLock(async () => {
+    try {
+      const response = await fetch(refreshEndpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Requested-With': 'XMLHttpRequest',
+          Cookie: `tb_access=${accessToken ?? ''}; tb_refresh=${refreshToken}`,
+        },
+      })
 
-    if (!response.ok) {
-      return null
-    }
-
-    // Forward Set-Cookie headers from the backend to the client
-    const setCookieHeaders = response.headers.getSetCookie?.() ?? []
-    for (const cookieHeader of setCookieHeaders) {
-      event.node.res.appendHeader('Set-Cookie', cookieHeader)
-    }
-
-    // Extract the new access token from Set-Cookie headers
-    for (const header of setCookieHeaders) {
-      const match = header.match(/tb_access=([^;]+)/)
-      if (match) {
-        return match[1]
+      if (!response.ok) {
+        return null
       }
-    }
-  } catch {
-    // Refresh failed
-  }
 
-  return null
+      // Forward Set-Cookie headers from the backend to the client
+      const setCookieHeaders = response.headers.getSetCookie?.() ?? []
+      for (const cookieHeader of setCookieHeaders) {
+        event.node.res.appendHeader('Set-Cookie', cookieHeader)
+      }
+
+      // Extract the new access token from Set-Cookie headers
+      for (const header of setCookieHeaders) {
+        const match = header.match(/tb_access=([^;]+)/)
+        if (match) {
+          return match[1]
+        }
+      }
+    } catch {
+      // Refresh failed
+    }
+
+    return null
+  })
 }

--- a/frontend/server/utils/refreshLock.ts
+++ b/frontend/server/utils/refreshLock.ts
@@ -1,0 +1,32 @@
+/**
+ * Prevents concurrent token refresh attempts (thundering herd problem).
+ *
+ * When multiple requests hit the BFF with an expired access token at the same
+ * time, each would independently attempt to refresh. Because the backend
+ * rotates the refresh token hash on every refresh, only the first succeeds —
+ * subsequent attempts use an already-invalidated token and fail, logging the
+ * user out.
+ *
+ * This module serializes refresh attempts: the first caller does the actual
+ * refresh, and all concurrent callers wait for that result.
+ */
+let activeRefresh: Promise<string | null> | null = null
+
+/**
+ * Execute a refresh callback, deduplicating concurrent calls.
+ * Returns the new access token string on success, or null on failure.
+ */
+export async function withRefreshLock (
+  refreshFn: () => Promise<string | null>,
+): Promise<string | null> {
+  if (activeRefresh) {
+    // Another request is already refreshing — wait for it
+    return activeRefresh
+  }
+
+  activeRefresh = refreshFn().finally(() => {
+    activeRefresh = null
+  })
+
+  return activeRefresh
+}


### PR DESCRIPTION
…aces

When multiple GraphQL requests hit the BFF simultaneously with an expired access token, each independently attempted to refresh. Because the backend rotates the refresh token hash on each refresh, only the first succeeded — subsequent attempts used an already-invalidated token and failed, logging the user out unexpectedly.

Changes:
- Add refresh lock (server/utils/refreshLock.ts) to serialize concurrent refresh attempts so only one runs and others wait for the result
- Extract new access token from Set-Cookie headers for immediate use in retries, since the h3 cookie jar doesn't reflect the new value
- Apply the lock to both graphql.ts and graphql-upload.ts BFF proxies and the SSR auth middleware
- Clear client-side auth store when the BFF returns auth errors after a failed refresh, so the UI reflects logged-out state immediately
- Hydrate unreadNotificationsCount from SSR auth context into the Pinia store (was fetched but never written)