### PR TITLE
fix(ui): fix broken post/comment actions (delete, report, remove)

### DIFF
--- a/frontend/components/comment/CommentActions.vue
+++ b/frontend/components/comment/CommentActions.vue
@@ -31,6 +31,7 @@ watch(() => props.comment.myVote, (v) => { localMyVote.value = v ?? 0 })
 
 const showRemoveDialog = ref(false)
 const showReportDialog = ref(false)
+const showDeleteConfirm = ref(false)
 const showModMenu = ref(false)
 const removeReason = ref('')
 const reportReason = ref('')
@@ -53,6 +54,12 @@ const REPORT_MUTATION = `
 const PIN_MUTATION = `
   mutation PinComment($commentId: ID!) {
     pinComment(commentId: $commentId) { id isPinned }
+  }
+`
+
+const DELETE_COMMENT_MUTATION = `
+  mutation DeleteComment($commentId: ID!) {
+    deleteComment(commentId: $commentId) { id }
   }
 `
 
@@ -101,6 +108,16 @@ async function toggleSaveComment (): Promise<void> {
   if (result) {
     commentSaved.value = !commentSaved.value
     toast.success(commentSaved.value ? 'Comment saved' : 'Comment unsaved')
+  }
+}
+
+async function deleteComment (): Promise<void> {
+  const { execute } = useGraphQL()
+  const result = await execute(DELETE_COMMENT_MUTATION, { variables: { commentId: props.comment.id } })
+  showDeleteConfirm.value = false
+  if (result) {
+    toast.success('Comment deleted')
+    emit('updated')
   }
 }
 
@@ -220,6 +237,18 @@ function openRemoveDialog (): void {
       Report
     </button>
 
+    <!-- Delete (own comments) -->
+    <button
+      v-if="authStore.isLoggedIn && isOwnComment"
+      class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded hover:bg-gray-100 hover:text-red-500 transition-colors"
+      @click="showDeleteConfirm = true"
+    >
+      <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+      </svg>
+      Delete
+    </button>
+
     <!-- Mod actions menu -->
     <template v-if="canModerate">
       <span class="text-gray-200 mx-0.5">|</span>
@@ -307,6 +336,20 @@ function openRemoveDialog (): void {
           <div class="flex gap-2 justify-end">
             <button class="button white button-sm" @click="showRemoveDialog = false">Cancel</button>
             <button class="button button-sm bg-red-600 text-white hover:bg-red-700" :disabled="acting" @click="handleRemove">Remove</button>
+          </div>
+        </div>
+      </template>
+    </CommonModal>
+
+    <!-- Delete confirmation -->
+    <CommonModal v-if="showDeleteConfirm" @close="showDeleteConfirm = false">
+      <template #title>Delete Comment</template>
+      <template #default>
+        <div class="space-y-3">
+          <p class="text-sm text-gray-600">Are you sure you want to delete this comment? This cannot be undone.</p>
+          <div class="flex gap-2 justify-end">
+            <button class="button white button-sm" @click="showDeleteConfirm = false">Cancel</button>
+            <button class="button button-sm bg-red-600 text-white hover:bg-red-700" @click="deleteComment">Delete</button>
           </div>
         </div>
       </template>

--- a/frontend/components/common/Modal.vue
+++ b/frontend/components/common/Modal.vue
@@ -8,10 +8,11 @@ import {
 } from '@headlessui/vue'
 
 withDefaults(defineProps<{
-  open: boolean
+  open?: boolean
   title?: string
   size?: 'sm' | 'md' | 'lg'
 }>(), {
+  open: true,
   title: undefined,
   size: 'md',
 })
@@ -59,8 +60,8 @@ const sizeClasses = {
               class="w-full rounded-lg bg-white shadow-xl p-6"
               :class="sizeClasses[size]"
             >
-              <DialogTitle v-if="title" class="text-lg font-semibold text-gray-900 mb-4">
-                {{ title }}
+              <DialogTitle v-if="title || $slots.title" class="text-lg font-semibold text-gray-900 mb-4">
+                <slot name="title">{{ title }}</slot>
               </DialogTitle>
               <slot />
             </DialogPanel>

--- a/frontend/components/thread/ThreadPost.vue
+++ b/frontend/components/thread/ThreadPost.vue
@@ -25,9 +25,16 @@ const { removeComment, restoreComment } = useModeration()
 
 const showRemoveDialog = ref(false)
 const showReportDialog = ref(false)
+const showDeleteConfirm = ref(false)
 const removeReason = ref('')
 const reportReason = ref('')
 const acting = ref(false)
+
+const DELETE_COMMENT_MUTATION = `
+  mutation DeleteComment($commentId: ID!) {
+    deleteComment(commentId: $commentId) { id }
+  }
+`
 
 const REPORT_MUTATION = `
   mutation ReportComment($commentId: ID!, $reason: String!) {
@@ -81,6 +88,13 @@ async function submitReport (): Promise<void> {
   await execute(REPORT_MUTATION, { variables: { commentId: props.comment.id, reason: reportReason.value } })
   showReportDialog.value = false
   reportReason.value = ''
+}
+
+async function deleteComment (): Promise<void> {
+  const { execute } = useGraphQL()
+  const result = await execute(DELETE_COMMENT_MUTATION, { variables: { commentId: props.comment.id } })
+  showDeleteConfirm.value = false
+  if (result) emit('updated')
 }
 
 async function togglePin (): Promise<void> {
@@ -177,6 +191,15 @@ async function togglePin (): Promise<void> {
           Report
         </button>
 
+        <!-- Delete (own comment) -->
+        <button
+          v-if="authStore.isLoggedIn && isOwnComment"
+          class="inline-flex items-center gap-1 px-2 py-1 rounded hover:bg-red-50 hover:text-red-500 transition-colors"
+          @click="showDeleteConfirm = true"
+        >
+          Delete
+        </button>
+
         <!-- Mod actions -->
         <template v-if="canModerate">
           <div class="w-px h-4 bg-gray-300 mx-1" />
@@ -221,6 +244,20 @@ async function togglePin (): Promise<void> {
           <div class="flex gap-2 justify-end">
             <button class="button white button-sm" @click="showRemoveDialog = false">Cancel</button>
             <button class="button button-sm bg-red-600 text-white hover:bg-red-700" :disabled="acting" @click="handleRemove">Remove</button>
+          </div>
+        </div>
+      </template>
+    </CommonModal>
+
+    <!-- Delete confirmation -->
+    <CommonModal v-if="showDeleteConfirm" @close="showDeleteConfirm = false">
+      <template #title>Delete Comment</template>
+      <template #default>
+        <div class="space-y-3">
+          <p class="text-sm text-gray-600">Are you sure you want to delete this comment? This cannot be undone.</p>
+          <div class="flex gap-2 justify-end">
+            <button class="button white button-sm" @click="showDeleteConfirm = false">Cancel</button>
+            <button class="button button-sm bg-red-600 text-white hover:bg-red-700" @click="deleteComment">Delete</button>
           </div>
         </div>
       </template>

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -155,6 +155,7 @@ type Mutation {
   lockPost(postId: ID!): Post!
   unlockPost(postId: ID!): Post!
   featurePost(postId: ID!, featured: Boolean!, featureType: String): Post!
+  deletePost(postId: ID!): Post!
   removePost(postId: ID!, reason: String): Post!
   restorePost(postId: ID!): Post!
 
@@ -164,6 +165,7 @@ type Mutation {
   voteOnComment(commentId: ID!, direction: Int!): Comment!
   saveComment(commentId: ID!): Comment!
   unsaveComment(commentId: ID!): Comment!
+  deleteComment(commentId: ID!): Comment!
   pinComment(commentId: ID!): Comment!
   removeComment(commentId: ID!, reason: String): Comment!
   restoreComment(commentId: ID!): Comment!

--- a/schema.graphql
+++ b/schema.graphql
@@ -155,6 +155,7 @@ type Mutation {
   lockPost(postId: ID!): Post!
   unlockPost(postId: ID!): Post!
   featurePost(postId: ID!, featured: Boolean!, featureType: String): Post!
+  deletePost(postId: ID!): Post!
   removePost(postId: ID!, reason: String): Post!
   restorePost(postId: ID!): Post!
 
@@ -164,6 +165,7 @@ type Mutation {
   voteOnComment(commentId: ID!, direction: Int!): Comment!
   saveComment(commentId: ID!): Comment!
   unsaveComment(commentId: ID!): Comment!
+  deleteComment(commentId: ID!): Comment!
   removeComment(commentId: ID!, reason: String): Comment!
   restoreComment(commentId: ID!): Comment!
   pinComment(commentId: ID!): Comment!


### PR DESCRIPTION
CommonModal required an `open` prop for headlessui TransitionRoot but no caller ever passed it, so every modal (delete, report, remove) was invisible on click. Default `open` to true so v-if mounting works.

Also added #title slot support to Modal (callers used named slots but the component only read a title prop).

Added missing deleteComment action to CommentActions and ThreadPost components with confirmation dialog. Updated both schema.graphql files with the deletePost and deleteComment mutations that existed in the backend but were never documented.