### PR TITLE
fix(admin): set initial admin level to 7 (Owner) and add distinguish …

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,7 +224,8 @@ revisions), flairs (management + post assignment),
 toast notifications, SEO (useSeoMeta + JSON-LD + robots.txt + sitemap),
 notification polling, thread system, rich user profiles (background,
 avatar frame, karma, signature), link preview rendering (YouTube embeds,
-video, thumbnails).
+video, thumbnails), distinguish feature (admin/mod badges on posts and
+comments with toggle).
 
 ### Not Yet Implemented
 - Email sending (SMTP) — blocks password reset & verification
@@ -277,8 +278,8 @@ video, thumbnails).
 `getBoardFlairs`, `getFlairTemplate`, `getModerationLog`
 
 ### Mutations (38+)
-**Posts:** create, edit, vote, save/unsave, hide/unhide, lock/unlock, feature, remove, restore
-**Comments:** create, edit, vote, save/unsave, remove, restore
+**Posts:** create, edit, vote, save/unsave, hide/unhide, lock/unlock, feature, remove, restore, distinguish
+**Comments:** create, edit, vote, save/unsave, remove, restore, distinguish
 **Boards:** create, updateSettings
 **Users:** follow/unfollow, block/unblock, updateSettings, updateProfile
 **Messages:** send, edit, delete
@@ -459,3 +460,9 @@ infallible `unwrap()` on date/time values.
 - Removed stream references from AppNav, AppSidebar, HomeSidebar, AllSidebar
 - Removed streams user guide documentation
 - Updated CLAUDE.md: project overview, feature status, GraphQL API lists, remaining work, session log
+
+### 2026-03-27 — Session 9: Admin Level Fix + Distinguish Feature
+- **Fixed initial admin level**: Changed from 256 to 7 (Owner) in code_migrations.rs. Level 256 was outside the valid 0-7 range and broke admin management.
+- **Owner-level admin promotion**: Updated set_user_admin_level and delete_account mutations so level 7 (Owner) admins can promote other users to Owner level and manage peer owners. Non-owner admins still cannot promote to their own level.
+- **Distinguish feature (admin/mod badges)**: Added `distinguished_as` nullable column to posts and comments tables (migration 000020). Values: NULL (not distinguished), 'admin', 'mod'. Admins and board mods can toggle a distinguish badge on their own posts/comments via `distinguishPost` and `distinguishComment` GraphQL mutations. Badge shows as green "Admin" or blue "Mod" in PostCard, PostDetail, and CommentItem. Toggle button appears in moderation menus for own content only.
+- Updated both GraphQL schema files, generated types, and all relevant frontend queries/composables

--- a/backend/crates/api/src/mutations/admin/user_management.rs
+++ b/backend/crates/api/src/mutations/admin/user_management.rs
@@ -112,8 +112,17 @@ impl UserManagement {
             );
         }
 
-        // Cannot set someone to your own level or higher
-        if admin_level >= admin.admin_level {
+        // Owners (level 7) can promote others up to their own level.
+        // All other admins can only assign levels strictly below their own.
+        if admin.admin_level >= 7 {
+            if admin_level > 7 {
+                return Err(TinyBoardsError::from_message(
+                    403,
+                    "Admin level must be between 0 and 7",
+                )
+                .into());
+            }
+        } else if admin_level >= admin.admin_level {
             return Err(TinyBoardsError::from_message(
                 403,
                 "Cannot grant an admin level equal to or higher than your own",
@@ -127,8 +136,8 @@ impl UserManagement {
             .await
             .map_err(|_| TinyBoardsError::NotFound("User not found".to_string()))?;
 
-        // Cannot modify someone at your level or above
-        if target.is_admin && target.admin_level >= admin.admin_level {
+        // Owners can modify other owners; lower admins cannot modify peers or superiors
+        if target.is_admin && target.admin_level >= admin.admin_level && admin.admin_level < 7 {
             return Err(TinyBoardsError::from_message(
                 403,
                 "Cannot modify an admin with equal or higher permissions",
@@ -214,7 +223,7 @@ impl UserManagement {
             .await
             .map_err(|_| TinyBoardsError::NotFound("User not found".to_string()))?;
 
-        if target.is_admin && target.admin_level >= admin.admin_level {
+        if target.is_admin && target.admin_level >= admin.admin_level && admin.admin_level < 7 {
             return Err(TinyBoardsError::from_message(
                 403,
                 "Cannot delete an admin with equal or higher permissions",

--- a/backend/crates/api/src/mutations/comment/moderation.rs
+++ b/backend/crates/api/src/mutations/comment/moderation.rs
@@ -204,4 +204,76 @@ impl CommentModeration {
             .await
             .map_err(|e| e.into())
     }
+
+    /// Toggle distinguish on a comment (mark as speaking officially as admin or mod).
+    /// Only the comment creator can distinguish, and only if they are an admin or mod of the board.
+    pub async fn distinguish_comment(
+        &self,
+        ctx: &Context<'_>,
+        comment_id: ID,
+    ) -> Result<Comment> {
+        let user = permissions::require_auth_not_banned(ctx)?;
+        let pool = ctx.data::<DbPool>()?;
+        let conn = &mut get_conn(pool).await?;
+
+        let comment_uuid: Uuid = comment_id
+            .parse()
+            .map_err(|_| TinyBoardsError::from_message(400, "Invalid comment ID"))?;
+
+        let comment: DbComment = comments::table
+            .find(comment_uuid)
+            .first(conn)
+            .await
+            .map_err(|_| TinyBoardsError::NotFound("Comment not found".into()))?;
+
+        // Only the comment creator can distinguish their own comments
+        if comment.creator_id != user.id {
+            return Err(
+                TinyBoardsError::from_message(403, "Only the comment creator can distinguish a comment")
+                    .into(),
+            );
+        }
+
+        // Determine the distinguish type based on the user's role
+        let new_distinguished = if comment.distinguished_as.is_some() {
+            // Toggle off
+            None
+        } else if user.is_admin && user.admin_level > 0 {
+            Some("admin".to_string())
+        } else {
+            // Check if user is a mod of this board
+            use tinyboards_db::schema::board_moderators;
+            let is_mod: bool = board_moderators::table
+                .filter(board_moderators::board_id.eq(comment.board_id))
+                .filter(board_moderators::user_id.eq(user.id))
+                .filter(board_moderators::is_invite_accepted.eq(true))
+                .count()
+                .get_result::<i64>(conn)
+                .await
+                .map(|c| c > 0)
+                .unwrap_or(false);
+
+            if is_mod {
+                Some("mod".to_string())
+            } else {
+                return Err(
+                    TinyBoardsError::from_message(403, "Must be an admin or board moderator to distinguish")
+                        .into(),
+                );
+            }
+        };
+
+        diesel::update(comments::table.find(comment_uuid))
+            .set(&CommentUpdateForm {
+                distinguished_as: Some(new_distinguished),
+                ..Default::default()
+            })
+            .execute(conn)
+            .await
+            .map_err(|e| TinyBoardsError::Database(e.to_string()))?;
+
+        load_comment_with_counts(conn, comment_uuid)
+            .await
+            .map_err(|e| e.into())
+    }
 }

--- a/backend/crates/api/src/mutations/post/moderation.rs
+++ b/backend/crates/api/src/mutations/post/moderation.rs
@@ -248,4 +248,76 @@ impl PostModeration {
             .await
             .map_err(|e| e.into())
     }
+
+    /// Toggle distinguish on a post (mark as speaking officially as admin or mod).
+    /// Only the post creator can distinguish, and only if they are an admin or mod of the board.
+    pub async fn distinguish_post(
+        &self,
+        ctx: &Context<'_>,
+        post_id: ID,
+    ) -> Result<Post> {
+        let user = permissions::require_auth_not_banned(ctx)?;
+        let pool = ctx.data::<DbPool>()?;
+        let conn = &mut get_conn(pool).await?;
+
+        let post_uuid: Uuid = post_id
+            .parse()
+            .map_err(|_| TinyBoardsError::from_message(400, "Invalid post ID"))?;
+
+        let post: DbPost = posts::table
+            .find(post_uuid)
+            .first(conn)
+            .await
+            .map_err(|_| TinyBoardsError::NotFound("Post not found".into()))?;
+
+        // Only the post creator can distinguish their own posts
+        if post.creator_id != user.id {
+            return Err(
+                TinyBoardsError::from_message(403, "Only the post creator can distinguish a post")
+                    .into(),
+            );
+        }
+
+        // Determine the distinguish type based on the user's role
+        let new_distinguished = if post.distinguished_as.is_some() {
+            // Toggle off
+            None
+        } else if user.is_admin && user.admin_level > 0 {
+            Some("admin".to_string())
+        } else {
+            // Check if user is a mod of this board
+            use tinyboards_db::schema::board_moderators;
+            let is_mod: bool = board_moderators::table
+                .filter(board_moderators::board_id.eq(post.board_id))
+                .filter(board_moderators::user_id.eq(user.id))
+                .filter(board_moderators::is_invite_accepted.eq(true))
+                .count()
+                .get_result::<i64>(conn)
+                .await
+                .map(|c| c > 0)
+                .unwrap_or(false);
+
+            if is_mod {
+                Some("mod".to_string())
+            } else {
+                return Err(
+                    TinyBoardsError::from_message(403, "Must be an admin or board moderator to distinguish")
+                        .into(),
+                );
+            }
+        };
+
+        diesel::update(posts::table.find(post_uuid))
+            .set(&PostUpdateForm {
+                distinguished_as: Some(new_distinguished),
+                ..Default::default()
+            })
+            .execute(conn)
+            .await
+            .map_err(|e| TinyBoardsError::Database(e.to_string()))?;
+
+        load_post_with_counts(conn, post_uuid)
+            .await
+            .map_err(|e| e.into())
+    }
 }

--- a/backend/crates/api/src/structs/comment.rs
+++ b/backend/crates/api/src/structs/comment.rs
@@ -45,6 +45,7 @@ pub struct Comment {
     pub quoted_comment_id: Option<String>,
     pub slug: String,
     pub approval_status: String,
+    pub distinguished_as: Option<String>,
     pub replies: Option<Vec<Self>>,
     // Internal UUID fields for dataloaders
     #[graphql(skip)]
@@ -180,6 +181,7 @@ impl From<(DbComment, DbCommentAggregates)> for Comment {
             quoted_comment_id: comment.quoted_comment_id.map(|id| id.to_string()),
             slug: comment.slug.clone(),
             approval_status: format!("{:?}", comment.approval_status).to_lowercase(),
+            distinguished_as: comment.distinguished_as.clone(),
             uuid_id: comment.id,
             uuid_creator_id: comment.creator_id,
             uuid_post_id: comment.post_id,

--- a/backend/crates/api/src/structs/post.rs
+++ b/backend/crates/api/src/structs/post.rs
@@ -54,6 +54,7 @@ pub struct Post {
     pub slug: String,
     pub is_thread: bool,
     pub approval_status: String,
+    pub distinguished_as: Option<String>,
     // Internal UUID fields for dataloaders
     #[graphql(skip)]
     pub(crate) uuid_id: Uuid,
@@ -282,6 +283,7 @@ impl From<(DbPost, DbPostAggregates)> for Post {
             slug: post.slug.clone(),
             is_thread: post.is_thread,
             approval_status: format!("{:?}", post.approval_status).to_lowercase(),
+            distinguished_as: post.distinguished_as.clone(),
             uuid_id: post.id,
             uuid_creator_id: post.creator_id,
             uuid_board_id: post.board_id,

--- a/backend/crates/db/src/models/comment/comments.rs
+++ b/backend/crates/db/src/models/comment/comments.rs
@@ -31,6 +31,7 @@ pub struct Comment {
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
     pub deleted_at: Option<DateTime<Utc>>,
+    pub distinguished_as: Option<String>,
 }
 
 /// Insert form for creating a new comment.
@@ -69,4 +70,5 @@ pub struct CommentUpdateForm {
     pub quoted_comment_id: Option<Option<Uuid>>,
     pub updated_at: Option<DateTime<Utc>>,
     pub deleted_at: Option<Option<DateTime<Utc>>>,
+    pub distinguished_as: Option<Option<String>>,
 }

--- a/backend/crates/db/src/models/post/posts.rs
+++ b/backend/crates/db/src/models/post/posts.rs
@@ -40,6 +40,7 @@ pub struct Post {
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
     pub deleted_at: Option<DateTime<Utc>>,
+    pub distinguished_as: Option<String>,
 }
 
 /// Insert form for creating a new post.
@@ -98,4 +99,5 @@ pub struct PostUpdateForm {
     pub last_crawl_date: Option<Option<DateTime<Utc>>>,
     pub updated_at: Option<DateTime<Utc>>,
     pub deleted_at: Option<Option<DateTime<Utc>>>,
+    pub distinguished_as: Option<Option<String>>,
 }

--- a/backend/crates/db/src/schema.rs
+++ b/backend/crates/db/src/schema.rs
@@ -276,6 +276,8 @@ diesel::table! {
         created_at -> Timestamptz,
         updated_at -> Timestamptz,
         deleted_at -> Nullable<Timestamptz>,
+        #[max_length = 10]
+        distinguished_as -> Nullable<Varchar>,
     }
 }
 
@@ -306,6 +308,8 @@ diesel::table! {
         created_at -> Timestamptz,
         updated_at -> Timestamptz,
         deleted_at -> Nullable<Timestamptz>,
+        #[max_length = 10]
+        distinguished_as -> Nullable<Varchar>,
     }
 }
 

--- a/backend/src/code_migrations.rs
+++ b/backend/src/code_migrations.rs
@@ -90,7 +90,7 @@ async fn initialize_site_and_admin_user(
             is_email_verified: true,
             is_banned: false,
             is_admin: true,
-            admin_level: 256,
+            admin_level: 7,
             is_bot_account: false,
             is_board_creation_approved: true,
             is_application_accepted: true,

--- a/frontend/components/comment/CommentActions.vue
+++ b/frontend/components/comment/CommentActions.vue
@@ -20,7 +20,7 @@ const emit = defineEmits<{
 const authStore = useAuthStore()
 const siteStore = useSiteStore()
 const toast = useToast()
-const { removeComment, restoreComment } = useModeration()
+const { removeComment, restoreComment, distinguishComment } = useModeration()
 
 // Local reactive state so vote updates are immediately visible
 const localScore = ref(props.comment.score)
@@ -159,6 +159,14 @@ async function togglePin (): Promise<void> {
   }
 }
 
+async function handleDistinguish (): Promise<void> {
+  acting.value = true
+  showModMenu.value = false
+  const success = await distinguishComment(props.comment.id)
+  acting.value = false
+  if (success) emit('updated')
+}
+
 function openRemoveDialog (): void {
   showModMenu.value = false
   showRemoveDialog.value = true
@@ -292,6 +300,20 @@ function openRemoveDialog (): void {
               <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
             </svg>
             {{ comment.isPinned ? 'Unpin' : 'Pin' }}
+          </button>
+
+          <!-- Distinguish (own comments only) -->
+          <button
+            v-if="isOwnComment"
+            class="w-full flex items-center gap-2 px-3 py-2 text-sm transition-colors"
+            :class="comment.distinguishedAs ? 'text-green-700 hover:bg-green-50' : 'text-gray-700 hover:bg-gray-50'"
+            :disabled="acting"
+            @click="handleDistinguish"
+          >
+            <svg class="w-4 h-4" :class="comment.distinguishedAs ? 'text-green-500' : 'text-gray-400'" fill="currentColor" viewBox="0 0 20 20">
+              <path d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+            </svg>
+            {{ comment.distinguishedAs ? 'Undistinguish' : 'Distinguish' }}
           </button>
 
           <div class="border-t border-gray-100 my-1" />

--- a/frontend/components/comment/CommentItem.vue
+++ b/frontend/components/comment/CommentItem.vue
@@ -55,6 +55,12 @@ function submitReply (): void {
         {{ comment.creator.displayName ?? comment.creator.name }}
       </NuxtLink>
       <span v-else class="text-gray-400 italic">[deleted]</span>
+      <span v-if="comment.distinguishedAs === 'admin'" class="inline-flex items-center px-1 py-0 rounded text-[10px] font-medium bg-green-100 text-green-700 border border-green-200 leading-4">
+        Admin
+      </span>
+      <span v-else-if="comment.distinguishedAs === 'mod'" class="inline-flex items-center px-1 py-0 rounded text-[10px] font-medium bg-blue-100 text-blue-700 border border-blue-200 leading-4">
+        Mod
+      </span>
       <span>&middot;</span>
       <time :datetime="comment.createdAt">{{ timeAgo(comment.createdAt) }}</time>
       <span v-if="comment.isPinned" class="inline-flex items-center rounded-full bg-amber-100 px-1.5 py-0.5 text-xs font-medium text-amber-800 ml-1">

--- a/frontend/components/post/PostCard.vue
+++ b/frontend/components/post/PostCard.vue
@@ -193,8 +193,11 @@ const hasLinkPreview = computed(() => {
             >
               {{ post.creator.displayName ?? post.creator.name }}
             </NuxtLink>
-            <span v-if="post.creator?.isAdmin" class="inline-flex items-center px-1 py-0 rounded text-[10px] font-medium bg-green-100 text-green-700 border border-green-200 leading-4">
+            <span v-if="post.distinguishedAs === 'admin'" class="inline-flex items-center px-1 py-0 rounded text-[10px] font-medium bg-green-100 text-green-700 border border-green-200 leading-4">
               Admin
+            </span>
+            <span v-else-if="post.distinguishedAs === 'mod'" class="inline-flex items-center px-1 py-0 rounded text-[10px] font-medium bg-blue-100 text-blue-700 border border-blue-200 leading-4">
+              Mod
             </span>
             <span class="text-gray-300">&middot;</span>
             <time :datetime="post.createdAt" class="text-xs text-gray-400">{{ timeAgo(post.createdAt) }}</time>

--- a/frontend/components/post/PostDetail.vue
+++ b/frontend/components/post/PostDetail.vue
@@ -20,7 +20,7 @@ const emit = defineEmits<{
 const authStore = useAuthStore()
 const toast = useToast()
 
-const { removePost: doRemovePost, restorePost: doRestorePost, lockPost: doLockPost, unlockPost: doUnlockPost, featurePost: doFeaturePost } = useModeration()
+const { removePost: doRemovePost, restorePost: doRestorePost, lockPost: doLockPost, unlockPost: doUnlockPost, featurePost: doFeaturePost, distinguishPost: doDistinguishPost } = useModeration()
 
 const SAVE_MUTATION = `mutation SavePost($postId: ID!) { savePost(postId: $postId) { id isSaved } }`
 const UNSAVE_MUTATION = `mutation UnsavePost($postId: ID!) { unsavePost(postId: $postId) { id isSaved } }`
@@ -109,6 +109,14 @@ async function handleRestore (): Promise<void> {
   if (success) emit('post-updated')
 }
 
+async function handleDistinguish (): Promise<void> {
+  acting.value = true
+  showMoreMenu.value = false
+  const success = await doDistinguishPost(props.post.id)
+  acting.value = false
+  if (success) emit('post-updated')
+}
+
 function openRemoveDialog (): void {
   showMoreMenu.value = false
   showRemoveDialog.value = true
@@ -184,6 +192,12 @@ function onClickOutsideMenu (e: Event): void {
           <NuxtLink v-if="post.creator" :to="`/@${post.creator.name}`" class="no-underline hover:underline text-gray-500">
             {{ post.creator.displayName ?? post.creator.name }}
           </NuxtLink>
+          <span v-if="post.distinguishedAs === 'admin'" class="inline-flex items-center px-1 py-0 rounded text-[10px] font-medium bg-green-100 text-green-700 border border-green-200 leading-4">
+            Admin
+          </span>
+          <span v-else-if="post.distinguishedAs === 'mod'" class="inline-flex items-center px-1 py-0 rounded text-[10px] font-medium bg-blue-100 text-blue-700 border border-blue-200 leading-4">
+            Mod
+          </span>
           <span>&middot;</span>
           <time :datetime="post.createdAt">{{ timeAgo(post.createdAt) }}</time>
           <span v-if="post.isNSFW" class="badge badge-red ml-1">NSFW</span>
@@ -316,6 +330,20 @@ function onClickOutsideMenu (e: Event): void {
                       <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
                     </svg>
                     {{ post.isFeaturedBoard ? 'Unpin post' : 'Pin post' }}
+                  </button>
+
+                  <!-- Distinguish (own posts only) -->
+                  <button
+                    v-if="isOwnPost"
+                    class="w-full flex items-center gap-2 px-3 py-2 text-sm transition-colors"
+                    :class="post.distinguishedAs ? 'text-green-700 hover:bg-green-50' : 'text-gray-700 hover:bg-gray-50'"
+                    :disabled="acting"
+                    @click="handleDistinguish"
+                  >
+                    <svg class="w-4 h-4" :class="post.distinguishedAs ? 'text-green-500' : 'text-gray-400'" fill="currentColor" viewBox="0 0 20 20">
+                      <path d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+                    </svg>
+                    {{ post.distinguishedAs ? 'Undistinguish' : 'Distinguish' }}
                   </button>
 
                   <div class="border-t border-gray-100 my-1" />

--- a/frontend/components/post/PostModActions.vue
+++ b/frontend/components/post/PostModActions.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import { useModeration } from '~/composables/useModeration'
+import { useAuthStore } from '~/stores/auth'
 import type { Post } from '~/types/generated'
 
 const props = defineProps<{
@@ -11,11 +12,21 @@ const emit = defineEmits<{
   updated: []
 }>()
 
-const { lockPost, unlockPost, featurePost, removePost, restorePost } = useModeration()
+const { lockPost, unlockPost, featurePost, removePost, restorePost, distinguishPost } = useModeration()
 
+const authStore = useAuthStore()
 const showRemoveDialog = ref(false)
 const removeReason = ref('')
 const acting = ref(false)
+
+const isOwnPost = computed(() => authStore.user?.id === props.post.creatorId)
+
+async function handleDistinguish (): Promise<void> {
+  acting.value = true
+  const success = await distinguishPost(props.post.id)
+  acting.value = false
+  if (success) emit('updated')
+}
 
 async function handleLockToggle (): Promise<void> {
   acting.value = true
@@ -76,6 +87,20 @@ async function handleRestore (): Promise<void> {
         <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
       </svg>
       {{ post.isFeaturedBoard ? 'Unpin' : 'Pin' }}
+    </button>
+
+    <!-- Distinguish (only for own posts) -->
+    <button
+      v-if="isOwnPost"
+      class="inline-flex items-center gap-1 px-2 py-1 rounded hover:bg-gray-100"
+      :class="post.distinguishedAs ? 'text-green-600 hover:text-green-700' : 'text-gray-500 hover:text-gray-700'"
+      :disabled="acting"
+      @click="handleDistinguish"
+    >
+      <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20">
+        <path d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+      </svg>
+      {{ post.distinguishedAs ? 'Undistinguish' : 'Distinguish' }}
     </button>
 
     <!-- Remove / Restore -->

--- a/frontend/composables/useComments.ts
+++ b/frontend/composables/useComments.ts
@@ -24,11 +24,13 @@ const COMMENTS_QUERY = `
       downvotes
       replyCount
       myVote
+      distinguishedAs
       creator {
         id
         name
         displayName
         avatar
+        isAdmin
       }
     }
   }
@@ -47,11 +49,13 @@ const CREATE_COMMENT_MUTATION = `
       upvotes
       downvotes
       myVote
+      distinguishedAs
       creator {
         id
         name
         displayName
         avatar
+        isAdmin
       }
     }
   }

--- a/frontend/composables/useModeration.ts
+++ b/frontend/composables/useModeration.ts
@@ -98,6 +98,18 @@ const DISMISS_REPORT_MUTATION = `
   }
 `
 
+const DISTINGUISH_POST_MUTATION = `
+  mutation DistinguishPost($postId: ID!) {
+    distinguishPost(postId: $postId) { id distinguishedAs }
+  }
+`
+
+const DISTINGUISH_COMMENT_MUTATION = `
+  mutation DistinguishComment($commentId: ID!) {
+    distinguishComment(commentId: $commentId) { id distinguishedAs }
+  }
+`
+
 export { type PostReportView, type CommentReportView }
 
 export function useModeration () {
@@ -215,6 +227,24 @@ export function useModeration () {
     return false
   }
 
+  async function distinguishPost (postId: string): Promise<boolean> {
+    const toast = useToast()
+    const { execute: exec, error: mutError } = useGraphQL()
+    const result = await exec(DISTINGUISH_POST_MUTATION, { variables: { postId } })
+    if (result) { toast.success('Post distinguish toggled'); return true }
+    toast.error(mutError.value?.message ?? 'Failed to toggle distinguish')
+    return false
+  }
+
+  async function distinguishComment (commentId: string): Promise<boolean> {
+    const toast = useToast()
+    const { execute: exec, error: mutError } = useGraphQL()
+    const result = await exec(DISTINGUISH_COMMENT_MUTATION, { variables: { commentId } })
+    if (result) { toast.success('Comment distinguish toggled'); return true }
+    toast.error(mutError.value?.message ?? 'Failed to toggle distinguish')
+    return false
+  }
+
   return {
     postReports,
     commentReports,
@@ -231,5 +261,7 @@ export function useModeration () {
     featurePost,
     resolveReport,
     dismissReport,
+    distinguishPost,
+    distinguishComment,
   }
 }

--- a/frontend/composables/usePosts.ts
+++ b/frontend/composables/usePosts.ts
@@ -33,6 +33,7 @@ const POSTS_QUERY = `
       altText
       embedTitle
       embedDescription
+      distinguishedAs
       board {
         id
         name
@@ -44,6 +45,7 @@ const POSTS_QUERY = `
         name
         displayName
         avatar
+        isAdmin
       }
     }
   }

--- a/frontend/pages/b/[board]/feed/[id]/[[slug]].vue
+++ b/frontend/pages/b/[board]/feed/[id]/[[slug]].vue
@@ -50,6 +50,7 @@ const POST_QUERY = `
       isSaved
       thumbnailUrl
       board { id name title icon }
+      distinguishedAs
       creator { id name displayName avatar isAdmin }
     }
   }

--- a/frontend/pages/b/[board]/threads/[id]/[[slug]].vue
+++ b/frontend/pages/b/[board]/threads/[id]/[[slug]].vue
@@ -48,6 +48,7 @@ const THREAD_QUERY = `
       myVote
       isSaved
       thumbnailUrl
+      distinguishedAs
       board { id name title icon }
       creator { id name displayName avatar isAdmin }
     }

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -158,6 +158,7 @@ type Mutation {
   deletePost(postId: ID!): Post!
   removePost(postId: ID!, reason: String): Post!
   restorePost(postId: ID!): Post!
+  distinguishPost(postId: ID!): Post!
 
   # Comments
   createComment(postId: ID!, body: String!, parentId: ID): Comment!
@@ -169,6 +170,7 @@ type Mutation {
   pinComment(commentId: ID!): Comment!
   removeComment(commentId: ID!, reason: String): Comment!
   restoreComment(commentId: ID!): Comment!
+  distinguishComment(commentId: ID!): Comment!
 
   # Boards
   createBoard(input: CreateBoardInput!, iconFile: Upload, bannerFile: Upload): CreateBoardResponse!
@@ -282,6 +284,7 @@ type Post {
   sourceUrl: String
   slug: String!
   approvalStatus: String!
+  distinguishedAs: String
   commentCount: Int!
   score: Int!
   upvotes: Int!
@@ -313,6 +316,7 @@ type Comment {
   boardId: ID!
   slug: String!
   approvalStatus: String!
+  distinguishedAs: String
   replies: [Comment!]
   score: Int!
   upvotes: Int!

--- a/frontend/types/generated.ts
+++ b/frontend/types/generated.ts
@@ -169,6 +169,7 @@ export type Comment = {
   createdAt: Scalars['String']['output'];
   creator?: Maybe<User>;
   creatorId: Scalars['ID']['output'];
+  distinguishedAs?: Maybe<Scalars['String']['output']>;
   downvotes: Scalars['Int']['output'];
   id: Scalars['ID']['output'];
   isDeleted: Scalars['Boolean']['output'];
@@ -1115,6 +1116,7 @@ export type Post = {
   bodyHTML: Scalars['String']['output'];
   commentCount: Scalars['Int']['output'];
   controversyRank: Scalars['Float']['output'];
+  distinguishedAs?: Maybe<Scalars['String']['output']>;
   createdAt: Scalars['String']['output'];
   creator?: Maybe<User>;
   creatorId: Scalars['ID']['output'];

--- a/migrations/2026-03-27-000020_add_distinguish/down.sql
+++ b/migrations/2026-03-27-000020_add_distinguish/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE posts DROP COLUMN IF EXISTS distinguished_as;
+ALTER TABLE comments DROP COLUMN IF EXISTS distinguished_as;

--- a/migrations/2026-03-27-000020_add_distinguish/up.sql
+++ b/migrations/2026-03-27-000020_add_distinguish/up.sql
@@ -1,0 +1,4 @@
+-- Add distinguished_as column to posts and comments.
+-- NULL = not distinguished, 'admin' = speaking as admin, 'mod' = speaking as moderator.
+ALTER TABLE posts ADD COLUMN distinguished_as VARCHAR(10) DEFAULT NULL;
+ALTER TABLE comments ADD COLUMN distinguished_as VARCHAR(10) DEFAULT NULL;

--- a/schema.graphql
+++ b/schema.graphql
@@ -158,6 +158,7 @@ type Mutation {
   deletePost(postId: ID!): Post!
   removePost(postId: ID!, reason: String): Post!
   restorePost(postId: ID!): Post!
+  distinguishPost(postId: ID!): Post!
 
   # Comments
   createComment(postId: ID!, body: String!, parentId: ID): Comment!
@@ -169,6 +170,7 @@ type Mutation {
   removeComment(commentId: ID!, reason: String): Comment!
   restoreComment(commentId: ID!): Comment!
   pinComment(commentId: ID!): Comment!
+  distinguishComment(commentId: ID!): Comment!
 
   # Boards
   createBoard(input: CreateBoardInput!, iconFile: Upload, bannerFile: Upload): CreateBoardResponse!
@@ -312,6 +314,7 @@ type Post {
   slug: String!
   isThread: Boolean!
   approvalStatus: String!
+  distinguishedAs: String
   commentCount: Int!
   score: Int!
   upvotes: Int!
@@ -349,6 +352,7 @@ type Comment {
   quotedCommentId: ID
   slug: String!
   approvalStatus: String!
+  distinguishedAs: String
   replies: [Comment!]
   score: Int!
   upvotes: Int!


### PR DESCRIPTION
…feature

Initial admin was created with level 256 (outside valid 0-7 range), breaking admin management. Owner-level admins can now promote others to Owner.

Added distinguish feature: admins and mods can toggle an official badge on their own posts and comments, visible as "Admin" (green) or "Mod" (blue).