### PR TITLE
feat(css): implement custom CSS at site and board level with visual w…

### DIFF
--- a/backend/crates/api/src/mutations/board/settings.rs
+++ b/backend/crates/api/src/mutations/board/settings.rs
@@ -16,7 +16,12 @@ use tinyboards_db::{
     schema::{board_aggregates, boards},
     utils::{get_conn, DbPool},
 };
-use tinyboards_utils::{parser::parse_markdown_opt, utils::custom_body_parsing, TinyBoardsError};
+use tinyboards_utils::{
+    css_sanitizer::{sanitize_css, MAX_BOARD_CSS_BYTES},
+    parser::parse_markdown_opt,
+    utils::custom_body_parsing,
+    TinyBoardsError,
+};
 use url::Url;
 use uuid::Uuid;
 
@@ -39,6 +44,7 @@ pub struct UpdateBoardSettingsInput {
     pub section_order: Option<String>,
     pub default_section: Option<String>,
     pub wiki_enabled: Option<bool>,
+    pub custom_css: Option<String>,
 }
 
 #[derive(SimpleObject)]
@@ -132,6 +138,17 @@ impl UpdateBoardSettings {
             None => None,
         };
 
+        // Sanitize custom CSS if provided
+        let sanitized_css = match input.custom_css {
+            Some(ref css) if !css.trim().is_empty() => {
+                let result = sanitize_css(css, MAX_BOARD_CSS_BYTES)
+                    .map_err(|e| TinyBoardsError::BadRequest(e))?;
+                Some(Some(result.css))
+            }
+            Some(_) => Some(None), // Empty string clears the CSS
+            None => None,
+        };
+
         // Build the update form — only fields that were provided are set, preserving existing data
         let board_form = BoardUpdateForm {
             title: input.title,
@@ -151,6 +168,7 @@ impl UpdateBoardSettings {
             section_order: input.section_order.map(Some),
             wiki_enabled: input.wiki_enabled,
             default_section: input.default_section.map(Some),
+            custom_css: sanitized_css,
             ..Default::default()
         };
 

--- a/backend/crates/api/src/mutations/site/config.rs
+++ b/backend/crates/api/src/mutations/site/config.rs
@@ -8,6 +8,7 @@ use tinyboards_db::{
     schema::site,
     utils::{get_conn, DbPool},
 };
+use tinyboards_utils::css_sanitizer::{sanitize_css, MAX_SITE_CSS_BYTES};
 
 use crate::{helpers::permissions, structs::site::LocalSite};
 
@@ -47,6 +48,8 @@ pub struct UpdateSiteConfigInput {
     pub link_filter_enabled: Option<bool>,
     pub banned_domains: Option<String>,
     pub registration_mode: Option<String>,
+    pub custom_css: Option<String>,
+    pub custom_css_enabled: Option<bool>,
 }
 
 #[Object]
@@ -64,6 +67,17 @@ impl SiteConfig {
         // Get existing site row
         let existing: DbSite = site::table.first(conn).await
             .map_err(|e| tinyboards_utils::TinyBoardsError::Database(format!("Site not found: {}", e)))?;
+
+        // Sanitize custom CSS if provided
+        let sanitized_css = match input.custom_css {
+            Some(ref css) if !css.trim().is_empty() => {
+                let result = sanitize_css(css, MAX_SITE_CSS_BYTES)
+                    .map_err(|e| tinyboards_utils::TinyBoardsError::BadRequest(e))?;
+                Some(Some(result.css))
+            }
+            Some(_) => Some(None), // Empty string clears the CSS
+            None => None,          // Not provided, leave unchanged
+        };
 
         let form = SiteUpdateForm {
             name: input.name,
@@ -96,6 +110,8 @@ impl SiteConfig {
             filtered_words: input.filtered_words.map(Some),
             link_filter_enabled: input.link_filter_enabled,
             banned_domains: input.banned_domains.map(Some),
+            custom_css: sanitized_css,
+            custom_css_enabled: input.custom_css_enabled,
             // Fields not in the input are left None (unchanged)
             default_post_listing_type: None,
             default_avatar: None,

--- a/backend/crates/api/src/structs/boards.rs
+++ b/backend/crates/api/src/structs/boards.rs
@@ -39,6 +39,7 @@ pub struct Board {
     pub users_active_half_year: i64,
     pub is_subscribed: bool,
     pub section_config: i32,
+    pub custom_css: Option<String>,
 }
 
 impl Board {
@@ -83,6 +84,7 @@ impl Board {
             users_active_half_year,
             is_subscribed,
             section_config,
+            custom_css: board.custom_css,
         }
     }
 }

--- a/backend/crates/api/src/structs/site.rs
+++ b/backend/crates/api/src/structs/site.rs
@@ -88,11 +88,14 @@ pub struct LocalSite {
     pub max_emojis_per_comment: Option<i32>,
     pub emoji_max_file_size_mb: i32,
     pub board_emojis_enabled: bool,
+    pub custom_css_enabled: bool,
     pub created_at: String,
     pub updated_at: String,
-    // Hidden field — only admins can see
+    // Hidden fields — only admins can see
     #[graphql(skip)]
     pub welcome_message_: Option<String>,
+    #[graphql(skip)]
+    pub custom_css_: Option<String>,
 }
 
 #[ComplexObject]
@@ -103,6 +106,22 @@ impl LocalSite {
         match user {
             Some(u) if u.has_permission(tinyboards_db::models::user::user::AdminPerms::Config) => {
                 self.welcome_message_.clone()
+            }
+            _ => None,
+        }
+    }
+
+    /// Custom CSS for the site. Returned to all users when custom_css_enabled is true,
+    /// so the frontend can inject it into a <style> tag. Admins always see it (for editing).
+    pub async fn custom_css(&self, ctx: &Context<'_>) -> Option<String> {
+        if self.custom_css_enabled {
+            return self.custom_css_.clone();
+        }
+        // If disabled, only admins can see it (so they can edit it before enabling)
+        let user = permissions::optional_auth(ctx);
+        match user {
+            Some(u) if u.has_permission(tinyboards_db::models::user::user::AdminPerms::Config) => {
+                self.custom_css_.clone()
             }
             _ => None,
         }
@@ -168,9 +187,11 @@ impl From<DbSite> for LocalSite {
             max_emojis_per_comment: v.max_emojis_per_comment,
             emoji_max_file_size_mb: v.emoji_max_file_size_mb,
             board_emojis_enabled: v.board_emojis_enabled,
+            custom_css_enabled: v.custom_css_enabled,
             created_at: v.created_at.to_rfc3339(),
             updated_at: v.updated_at.to_rfc3339(),
             welcome_message_: v.welcome_message,
+            custom_css_: v.custom_css,
         }
     }
 }

--- a/backend/crates/db/src/models/board/boards.rs
+++ b/backend/crates/db/src/models/board/boards.rs
@@ -40,6 +40,7 @@ pub struct Board {
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
     pub deleted_at: Option<DateTime<Utc>>,
+    pub custom_css: Option<String>,
 }
 
 /// Form for inserting a new board.
@@ -73,6 +74,7 @@ pub struct BoardInsertForm {
     pub wiki_require_approval: Option<bool>,
     pub wiki_default_view_permission: DbWikiPermission,
     pub wiki_default_edit_permission: DbWikiPermission,
+    pub custom_css: Option<String>,
 }
 
 /// Form for updating an existing board. All fields optional so only
@@ -108,4 +110,5 @@ pub struct BoardUpdateForm {
     pub wiki_default_view_permission: Option<DbWikiPermission>,
     pub wiki_default_edit_permission: Option<DbWikiPermission>,
     pub deleted_at: Option<Option<DateTime<Utc>>>,
+    pub custom_css: Option<Option<String>>,
 }

--- a/backend/crates/db/src/models/site/site.rs
+++ b/backend/crates/db/src/models/site/site.rs
@@ -64,6 +64,8 @@ pub struct Site {
     pub image_strip_exif: bool,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    pub custom_css: Option<String>,
+    pub custom_css_enabled: bool,
 }
 
 /// Form for inserting a new site row.
@@ -117,6 +119,8 @@ pub struct SiteInsertForm {
     pub max_emojis_per_comment: Option<i32>,
     pub emoji_max_file_size_mb: i32,
     pub board_emojis_enabled: bool,
+    pub custom_css: Option<String>,
+    pub custom_css_enabled: bool,
 }
 
 /// Form for updating an existing site row. All fields are optional so only
@@ -171,4 +175,6 @@ pub struct SiteUpdateForm {
     pub max_emojis_per_comment: Option<Option<i32>>,
     pub emoji_max_file_size_mb: Option<i32>,
     pub board_emojis_enabled: Option<bool>,
+    pub custom_css: Option<Option<String>>,
+    pub custom_css_enabled: Option<bool>,
 }

--- a/backend/crates/db/src/schema.rs
+++ b/backend/crates/db/src/schema.rs
@@ -124,6 +124,8 @@ diesel::table! {
         image_strip_exif -> Bool,
         created_at -> Timestamptz,
         updated_at -> Timestamptz,
+        custom_css -> Nullable<Text>,
+        custom_css_enabled -> Bool,
     }
 }
 
@@ -214,6 +216,7 @@ diesel::table! {
         created_at -> Timestamptz,
         updated_at -> Timestamptz,
         deleted_at -> Nullable<Timestamptz>,
+        custom_css -> Nullable<Text>,
     }
 }
 

--- a/backend/crates/utils/src/css_sanitizer.rs
+++ b/backend/crates/utils/src/css_sanitizer.rs
@@ -1,0 +1,203 @@
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+/// Maximum allowed CSS length in bytes (50 KB for site, 25 KB for board).
+pub const MAX_SITE_CSS_BYTES: usize = 50 * 1024;
+pub const MAX_BOARD_CSS_BYTES: usize = 25 * 1024;
+
+/// Patterns that are never allowed in custom CSS — these can be used for XSS,
+/// data exfiltration, or to hijack the page layout in dangerous ways.
+static DANGEROUS_PATTERNS: Lazy<Vec<Regex>> = Lazy::new(|| {
+    vec![
+        // Script injection / expression evaluation
+        Regex::new(r"(?i)expression\s*\(").unwrap(),
+        Regex::new(r"(?i)javascript\s*:").unwrap(),
+        Regex::new(r"(?i)vbscript\s*:").unwrap(),
+        // Legacy IE behaviors
+        Regex::new(r"(?i)behavior\s*:").unwrap(),
+        Regex::new(r"(?i)-moz-binding\s*:").unwrap(),
+        // Data exfiltration via external resources
+        Regex::new(r"(?i)@import").unwrap(),
+        Regex::new(r"(?i)@charset").unwrap(),
+        Regex::new(r"(?i)@namespace").unwrap(),
+        // url() can load external resources — block it entirely
+        Regex::new(r"(?i)url\s*\(").unwrap(),
+        // Block HTML tags that may have been injected
+        Regex::new(r"<\s*/?(?:script|style|link|meta|iframe|object|embed|applet|form|input|svg|math)").unwrap(),
+        // Unicode escape sequences used to bypass keyword filters
+        Regex::new(r"\\[0-9a-fA-F]{1,6}").unwrap(),
+    ]
+});
+
+/// CSS properties that could be used to overlay content or break the admin UI.
+static BLOCKED_PROPERTY_VALUES: Lazy<Vec<Regex>> = Lazy::new(|| {
+    vec![
+        // Fixed/sticky positioning can overlay nav, modals, etc.
+        Regex::new(r"(?i)position\s*:\s*(fixed|sticky)").unwrap(),
+        // Very high z-index can break modals and overlays
+        Regex::new(r"(?i)z-index\s*:\s*(\d{5,})").unwrap(),
+    ]
+});
+
+/// Result of CSS sanitization.
+#[derive(Debug)]
+pub struct CssSanitizeResult {
+    pub css: String,
+    pub warnings: Vec<String>,
+}
+
+/// Sanitize a CSS string for safe injection into the page.
+///
+/// This validates the CSS and strips anything that could be used for XSS,
+/// data exfiltration, or to break the site's UI. Returns the cleaned CSS
+/// and any warnings about removed content.
+pub fn sanitize_css(input: &str, max_bytes: usize) -> Result<CssSanitizeResult, String> {
+    if input.trim().is_empty() {
+        return Ok(CssSanitizeResult {
+            css: String::new(),
+            warnings: vec![],
+        });
+    }
+
+    if input.len() > max_bytes {
+        return Err(format!(
+            "CSS exceeds maximum allowed size of {} KB",
+            max_bytes / 1024
+        ));
+    }
+
+    let mut warnings = Vec::new();
+    let mut css = input.to_string();
+
+    // Check for dangerous patterns
+    for pattern in DANGEROUS_PATTERNS.iter() {
+        if pattern.is_match(&css) {
+            let matched = pattern
+                .find(&css)
+                .map(|m| m.as_str().to_string())
+                .unwrap_or_default();
+            warnings.push(format!("Blocked pattern removed: {}", matched.trim()));
+            css = pattern.replace_all(&css, "/* blocked */").to_string();
+        }
+    }
+
+    // Check for blocked property values
+    for pattern in BLOCKED_PROPERTY_VALUES.iter() {
+        if pattern.is_match(&css) {
+            let matched = pattern
+                .find(&css)
+                .map(|m| m.as_str().to_string())
+                .unwrap_or_default();
+            warnings.push(format!("Blocked property value removed: {}", matched.trim()));
+            css = pattern.replace_all(&css, "/* blocked */").to_string();
+        }
+    }
+
+    // Strip any remaining HTML-like content
+    let html_tag_re = Regex::new(r"<[^>]*>").unwrap();
+    if html_tag_re.is_match(&css) {
+        warnings.push("HTML tags removed from CSS".to_string());
+        css = html_tag_re.replace_all(&css, "").to_string();
+    }
+
+    // Verify balanced braces — unbalanced CSS can break the page
+    let open_braces = css.chars().filter(|c| *c == '{').count();
+    let close_braces = css.chars().filter(|c| *c == '}').count();
+    if open_braces != close_braces {
+        return Err(format!(
+            "Unbalanced braces: {} opening vs {} closing. Please check your CSS syntax.",
+            open_braces, close_braces
+        ));
+    }
+
+    Ok(CssSanitizeResult { css, warnings })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_clean_css_passes() {
+        let css = r#"
+            .post-card { background: #f0f0f0; border-radius: 8px; }
+            .header { color: #333; font-size: 1.2rem; }
+            @media (max-width: 768px) { .sidebar { display: none; } }
+        "#;
+        let result = sanitize_css(css, MAX_SITE_CSS_BYTES).unwrap();
+        assert!(result.warnings.is_empty());
+        assert!(result.css.contains(".post-card"));
+    }
+
+    #[test]
+    fn test_blocks_javascript() {
+        let css = "div { background: javascript:alert(1); }";
+        let result = sanitize_css(css, MAX_SITE_CSS_BYTES).unwrap();
+        assert!(!result.warnings.is_empty());
+        assert!(result.css.contains("/* blocked */"));
+    }
+
+    #[test]
+    fn test_blocks_import() {
+        let css = "@import url('evil.css'); .safe { color: red; }";
+        let result = sanitize_css(css, MAX_SITE_CSS_BYTES).unwrap();
+        assert!(!result.warnings.is_empty());
+    }
+
+    #[test]
+    fn test_blocks_expression() {
+        let css = "div { width: expression(document.body.clientWidth); }";
+        let result = sanitize_css(css, MAX_SITE_CSS_BYTES).unwrap();
+        assert!(!result.warnings.is_empty());
+    }
+
+    #[test]
+    fn test_blocks_url() {
+        let css = "div { background: url('https://evil.com/track.png'); }";
+        let result = sanitize_css(css, MAX_SITE_CSS_BYTES).unwrap();
+        assert!(!result.warnings.is_empty());
+    }
+
+    #[test]
+    fn test_blocks_fixed_position() {
+        let css = "div { position: fixed; top: 0; left: 0; }";
+        let result = sanitize_css(css, MAX_SITE_CSS_BYTES).unwrap();
+        assert!(!result.warnings.is_empty());
+    }
+
+    #[test]
+    fn test_rejects_unbalanced_braces() {
+        let css = ".test { color: red; ";
+        let result = sanitize_css(css, MAX_SITE_CSS_BYTES);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_rejects_oversized_css() {
+        let css = "a".repeat(MAX_SITE_CSS_BYTES + 1);
+        let result = sanitize_css(&css, MAX_SITE_CSS_BYTES);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_empty_css() {
+        let result = sanitize_css("", MAX_SITE_CSS_BYTES).unwrap();
+        assert!(result.css.is_empty());
+        assert!(result.warnings.is_empty());
+    }
+
+    #[test]
+    fn test_allows_media_queries() {
+        let css = "@media (prefers-color-scheme: dark) { body { background: #1a1a1a; } }";
+        let result = sanitize_css(css, MAX_SITE_CSS_BYTES).unwrap();
+        assert!(result.warnings.is_empty());
+        assert!(result.css.contains("@media"));
+    }
+
+    #[test]
+    fn test_allows_keyframes() {
+        let css = "@keyframes fade { from { opacity: 0; } to { opacity: 1; } }";
+        let result = sanitize_css(css, MAX_SITE_CSS_BYTES).unwrap();
+        assert!(result.warnings.is_empty());
+    }
+}

--- a/backend/crates/utils/src/lib.rs
+++ b/backend/crates/utils/src/lib.rs
@@ -7,6 +7,7 @@ pub mod utils;
 pub mod version;
 pub mod email;
 pub mod content_filter;
+pub mod css_sanitizer;
 pub mod slug;
 
 pub use error::TinyBoardsError;

--- a/frontend/components/common/BoardCssInjector.vue
+++ b/frontend/components/common/BoardCssInjector.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+/**
+ * Injects board-level custom CSS into the page when viewing a board.
+ * The board CSS is placed AFTER site CSS in the cascade, so it overrides site styles.
+ *
+ * CSS cascade order:
+ *   1. Built-in theme (via Tailwind + theme classes)
+ *   2. Site custom CSS (injected by theme.client.ts plugin via #tb-site-custom-css)
+ *   3. Board custom CSS (injected by this component via #tb-board-custom-css)
+ */
+
+const props = defineProps<{
+  css: string | null | undefined
+}>()
+
+const styleId = 'tb-board-custom-css'
+
+function applyBoardCss () {
+  if (!import.meta.client) return
+
+  let el = document.getElementById(styleId) as HTMLStyleElement | null
+  if (props.css) {
+    if (!el) {
+      el = document.createElement('style')
+      el.id = styleId
+      el.setAttribute('data-source', 'board-mod')
+      document.head.appendChild(el)
+    }
+    el.textContent = props.css
+  } else if (el) {
+    el.textContent = ''
+  }
+}
+
+function removeBoardCss () {
+  if (!import.meta.client) return
+  const el = document.getElementById(styleId)
+  if (el) {
+    el.textContent = ''
+  }
+}
+
+watch(() => props.css, applyBoardCss, { immediate: true })
+
+onMounted(applyBoardCss)
+onBeforeUnmount(removeBoardCss)
+</script>
+
+<template>
+  <!-- Renderless component — CSS is injected directly into document.head -->
+  <span v-if="false" />
+</template>

--- a/frontend/composables/useBoard.ts
+++ b/frontend/composables/useBoard.ts
@@ -29,6 +29,7 @@ const BOARD_QUERY = `
       isSubscribed
       sectionConfig
       wikiEnabled
+      customCss
     }
   }
 `

--- a/frontend/middleware/01.site.global.ts
+++ b/frontend/middleware/01.site.global.ts
@@ -30,6 +30,8 @@ const SITE_QUERY = `
       enableNSFWTagging
       wordFilterEnabled
       welcomeMessage
+      customCss
+      customCssEnabled
     }
   }
 `

--- a/frontend/pages/admin/css.vue
+++ b/frontend/pages/admin/css.vue
@@ -1,17 +1,434 @@
 <script setup lang="ts">
+import { useGraphQL, useGraphQLMutation } from '~/composables/useGraphQL'
+import { useToast } from '~/composables/useToast'
+import { validateCss, CSS_SNIPPET_CATEGORIES } from '~/utils/css-validator'
+import type { CssSnippet } from '~/utils/css-validator'
+
 definePageMeta({ layout: 'admin' })
 useHead({ title: 'Admin - Custom CSS' })
+
+const toast = useToast()
+
+// ---------------------------------------------------------------------------
+// Data fetching
+// ---------------------------------------------------------------------------
+const SITE_CSS_QUERY = `
+  query GetSiteCss {
+    site {
+      customCss
+      customCssEnabled
+    }
+  }
+`
+
+const UPDATE_CSS_MUTATION = `
+  mutation UpdateSiteCSS($input: UpdateSiteConfigInput!) {
+    updateSiteConfig(input: $input) {
+      customCss
+      customCssEnabled
+    }
+  }
+`
+
+const { execute, loading } = useGraphQL<{ site: { customCss: string | null; customCssEnabled: boolean } }>()
+const { execute: executeMutation, loading: saving } = useGraphQLMutation()
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+const cssCode = ref('')
+const cssEnabled = ref(false)
+const activeTab = ref<'editor' | 'wizard' | 'preview'>('wizard')
+const expandedCategory = ref<string | null>(null)
+const previewCss = ref('')
+const showPreview = ref(false)
+
+// Validation
+const validation = computed(() => validateCss(cssCode.value))
+const charCount = computed(() => new Blob([cssCode.value]).size)
+const maxBytes = 50 * 1024
+
+// ---------------------------------------------------------------------------
+// Load current CSS
+// ---------------------------------------------------------------------------
+onMounted(async () => {
+  const result = await execute(SITE_CSS_QUERY)
+  if (result?.site) {
+    cssCode.value = result.site.customCss ?? ''
+    cssEnabled.value = result.site.customCssEnabled
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Actions
+// ---------------------------------------------------------------------------
+function insertSnippet (snippet: CssSnippet) {
+  if (cssCode.value && !cssCode.value.endsWith('\n')) {
+    cssCode.value += '\n'
+  }
+  cssCode.value += `\n/* ${snippet.name} */\n${snippet.css}\n`
+  activeTab.value = 'editor'
+  toast.success(`Inserted: ${snippet.name}`)
+}
+
+function toggleCategory (name: string) {
+  expandedCategory.value = expandedCategory.value === name ? null : name
+}
+
+function updatePreview () {
+  previewCss.value = cssCode.value
+  showPreview.value = true
+  activeTab.value = 'preview'
+}
+
+function clearCss () {
+  cssCode.value = ''
+  toast.info('CSS cleared')
+}
+
+async function saveCss () {
+  if (!validation.value.valid) {
+    toast.error('Please fix CSS errors before saving')
+    return
+  }
+
+  const result = await executeMutation(UPDATE_CSS_MUTATION, {
+    variables: {
+      input: {
+        customCss: cssCode.value || '',
+        customCssEnabled: cssEnabled.value,
+      },
+    },
+  })
+
+  if (result) {
+    toast.success('Custom CSS saved successfully')
+    // Reload site store so changes take effect immediately
+    const siteStore = useSiteStore()
+    if (siteStore.site) {
+      siteStore.site.customCss = cssCode.value || null
+      siteStore.site.customCssEnabled = cssEnabled.value
+    }
+  }
+}
+
+// Category icon mapping
+function getCategoryIcon (icon: string): string {
+  const icons: Record<string, string> = {
+    'rectangle-stack': '\u25A1',
+    'font': 'Aa',
+    'palette': '\u25CE',
+    'layout': '\u2B1C',
+    'cursor-click': '\u25B6',
+    'chat-bubble': '\u25AC',
+    'sparkles': '\u2728',
+    'moon': '\u25D0',
+  }
+  return icons[icon] || '\u2022'
+}
 </script>
 
 <template>
-  <div>
-    <h2 class="text-lg font-semibold text-gray-900 mb-6">
-      Custom CSS
-    </h2>
-    <div class="rounded-md bg-yellow-50 border border-yellow-200 p-4">
-      <p class="text-sm text-yellow-800">
-        Custom CSS is not yet available. This feature will be added in a future update.
-      </p>
+  <div class="max-w-5xl">
+    <!-- Header -->
+    <div class="flex items-center justify-between mb-6">
+      <div>
+        <h2 class="text-lg font-semibold text-gray-900">
+          Custom CSS
+        </h2>
+        <p class="text-sm text-gray-500 mt-1">
+          Add custom styles to your site. Board moderators can also add board-level CSS that overrides these styles.
+        </p>
+      </div>
+
+      <!-- Enable toggle -->
+      <label class="flex items-center gap-3 cursor-pointer select-none">
+        <span class="text-sm font-medium" :class="cssEnabled ? 'text-green-700' : 'text-gray-500'">
+          {{ cssEnabled ? 'Enabled' : 'Disabled' }}
+        </span>
+        <button
+          type="button"
+          role="switch"
+          :aria-checked="cssEnabled"
+          :class="cssEnabled ? 'bg-green-500' : 'bg-gray-300'"
+          class="relative inline-flex h-6 w-11 shrink-0 rounded-full transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
+          @click="cssEnabled = !cssEnabled"
+        >
+          <span
+            :class="cssEnabled ? 'translate-x-5' : 'translate-x-0'"
+            class="pointer-events-none inline-block h-5 w-5 translate-y-0.5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ml-0.5"
+          />
+        </button>
+      </label>
     </div>
+
+    <CommonLoadingSpinner v-if="loading" size="lg" />
+
+    <template v-else>
+      <!-- Safety notice -->
+      <div class="rounded-lg bg-blue-50 border border-blue-200 p-4 mb-6">
+        <div class="flex gap-3">
+          <div class="text-blue-500 text-lg shrink-0">&#9432;</div>
+          <div class="text-sm text-blue-800">
+            <p class="font-medium mb-1">Safety Information</p>
+            <ul class="list-disc ml-4 space-y-0.5 text-blue-700">
+              <li>CSS is sanitized on the server — dangerous patterns are automatically blocked</li>
+              <li><code class="text-xs bg-blue-100 rounded px-1">@import</code>, <code class="text-xs bg-blue-100 rounded px-1">url()</code>, <code class="text-xs bg-blue-100 rounded px-1">expression()</code>, and <code class="text-xs bg-blue-100 rounded px-1">position: fixed</code> are not allowed</li>
+              <li>Maximum size: 50 KB. Use the wizard tab for quick, safe customizations</li>
+              <li><code class="text-xs bg-blue-100 rounded px-1">@media</code> queries and <code class="text-xs bg-blue-100 rounded px-1">@keyframes</code> animations are allowed</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+
+      <!-- Tabs -->
+      <div class="flex gap-1 border-b border-gray-200 mb-4">
+        <button
+          v-for="tab in [
+            { id: 'wizard', label: 'Style Wizard' },
+            { id: 'editor', label: 'CSS Editor' },
+            { id: 'preview', label: 'Live Preview' },
+          ]"
+          :key="tab.id"
+          :class="activeTab === tab.id
+            ? 'border-primary text-primary'
+            : 'border-transparent text-gray-500 hover:text-gray-700'"
+          class="px-4 py-2 text-sm font-medium border-b-2 transition-colors"
+          @click="activeTab = tab.id as 'editor' | 'wizard' | 'preview'"
+        >
+          {{ tab.label }}
+        </button>
+      </div>
+
+      <!-- ============================================ -->
+      <!-- WIZARD TAB -->
+      <!-- ============================================ -->
+      <div v-if="activeTab === 'wizard'" class="space-y-3">
+        <p class="text-sm text-gray-600 mb-4">
+          Click a snippet to add it to your CSS. You can then customize it in the editor tab.
+        </p>
+
+        <div
+          v-for="category in CSS_SNIPPET_CATEGORIES"
+          :key="category.name"
+          class="border border-gray-200 rounded-lg overflow-hidden"
+        >
+          <!-- Category header -->
+          <button
+            class="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-gray-50 transition-colors"
+            @click="toggleCategory(category.name)"
+          >
+            <span class="text-lg w-6 text-center opacity-70">{{ getCategoryIcon(category.icon) }}</span>
+            <span class="font-medium text-sm text-gray-900 flex-1">{{ category.name }}</span>
+            <span class="text-xs text-gray-400">{{ category.snippets.length }} snippets</span>
+            <span
+              class="text-gray-400 transition-transform duration-200"
+              :class="expandedCategory === category.name ? 'rotate-90' : ''"
+            >&#9656;</span>
+          </button>
+
+          <!-- Snippets -->
+          <div v-if="expandedCategory === category.name" class="border-t border-gray-100 divide-y divide-gray-100">
+            <div
+              v-for="snippet in category.snippets"
+              :key="snippet.name"
+              class="p-4 hover:bg-gray-50 transition-colors"
+            >
+              <div class="flex items-start justify-between gap-4">
+                <div class="flex-1 min-w-0">
+                  <div class="font-medium text-sm text-gray-900">{{ snippet.name }}</div>
+                  <div class="text-xs text-gray-500 mt-0.5">{{ snippet.description }}</div>
+                  <pre class="mt-2 text-xs bg-gray-900 text-green-400 rounded-md p-3 overflow-x-auto font-mono leading-relaxed"><code>{{ snippet.css }}</code></pre>
+                </div>
+                <button
+                  class="shrink-0 button primary button-sm"
+                  @click="insertSnippet(snippet)"
+                >
+                  Insert
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- ============================================ -->
+      <!-- EDITOR TAB -->
+      <!-- ============================================ -->
+      <div v-if="activeTab === 'editor'" class="space-y-4">
+        <!-- Toolbar -->
+        <div class="flex items-center justify-between">
+          <div class="flex items-center gap-2">
+            <button class="button white button-sm" @click="updatePreview">
+              Preview
+            </button>
+            <button class="button white button-sm text-red-600" :disabled="!cssCode" @click="clearCss">
+              Clear All
+            </button>
+          </div>
+          <div class="text-xs text-gray-400">
+            {{ (charCount / 1024).toFixed(1) }} KB / {{ maxBytes / 1024 }} KB
+          </div>
+        </div>
+
+        <!-- Editor -->
+        <div class="relative">
+          <textarea
+            v-model="cssCode"
+            class="w-full h-96 font-mono text-sm bg-gray-900 text-green-400 rounded-lg p-4 border border-gray-700 focus:border-primary focus:ring-1 focus:ring-primary resize-y leading-relaxed"
+            placeholder="/* Write your custom CSS here */
+
+.post-card {
+  border-radius: 12px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+}"
+            spellcheck="false"
+            autocomplete="off"
+            autocorrect="off"
+            autocapitalize="off"
+          />
+          <!-- Line count indicator -->
+          <div class="absolute bottom-3 right-3 text-xs text-gray-500 bg-gray-800 rounded px-2 py-1">
+            {{ cssCode.split('\n').length }} lines
+          </div>
+        </div>
+
+        <!-- Validation feedback -->
+        <div v-if="cssCode && !validation.valid" class="rounded-lg bg-red-50 border border-red-200 p-3">
+          <div class="text-sm font-medium text-red-800 mb-1">Validation Errors</div>
+          <ul class="list-disc ml-4 text-sm text-red-700 space-y-0.5">
+            <li v-for="(err, i) in validation.errors" :key="i">{{ err }}</li>
+          </ul>
+        </div>
+
+        <div v-if="cssCode && validation.warnings.length > 0" class="rounded-lg bg-yellow-50 border border-yellow-200 p-3">
+          <div class="text-sm font-medium text-yellow-800 mb-1">Warnings</div>
+          <ul class="list-disc ml-4 text-sm text-yellow-700 space-y-0.5">
+            <li v-for="(warn, i) in validation.warnings" :key="i">{{ warn }}</li>
+          </ul>
+        </div>
+
+        <div v-if="cssCode && validation.valid && validation.warnings.length === 0" class="flex items-center gap-2 text-sm text-green-700">
+          <span>&#10003;</span> CSS is valid
+        </div>
+      </div>
+
+      <!-- ============================================ -->
+      <!-- PREVIEW TAB -->
+      <!-- ============================================ -->
+      <div v-if="activeTab === 'preview'" class="space-y-4">
+        <div class="flex items-center justify-between">
+          <p class="text-sm text-gray-500">
+            This preview shows how your custom CSS will affect the page. Changes are temporary until you save.
+          </p>
+          <button class="button white button-sm" @click="updatePreview">
+            Refresh Preview
+          </button>
+        </div>
+
+        <!-- Preview frame -->
+        <div class="border border-gray-200 rounded-lg overflow-hidden">
+          <!-- Mini header preview -->
+          <div class="px-4 py-3 bg-primary text-white text-sm font-medium flex items-center gap-2 preview-header">
+            <span class="w-6 h-6 rounded bg-white/20" />
+            <span>Site Header Preview</span>
+            <span class="ml-auto flex gap-2">
+              <span class="text-xs opacity-70">Home</span>
+              <span class="text-xs opacity-70">Boards</span>
+              <span class="text-xs opacity-70">Search</span>
+            </span>
+          </div>
+
+          <!-- Mini content preview -->
+          <div class="p-4 bg-gray-100 preview-body" style="min-height: 300px">
+            <div class="max-w-2xl mx-auto space-y-3">
+              <!-- Post card preview -->
+              <div class="post-card bg-white rounded-lg border border-gray-200 p-4">
+                <div class="flex gap-3">
+                  <div class="flex flex-col items-center gap-1">
+                    <button class="vote-button text-gray-400 hover:text-primary text-lg">&#9650;</button>
+                    <span class="text-sm font-medium text-gray-700">42</span>
+                    <button class="vote-button text-gray-400 hover:text-red-500 text-lg">&#9660;</button>
+                  </div>
+                  <div class="flex-1">
+                    <div class="post-title text-base font-semibold text-gray-900">Example Post Title</div>
+                    <div class="text-xs text-gray-500 mt-1">Posted by <span class="text-primary">u/example</span> in <span class="font-medium">b/general</span> &middot; 2h ago</div>
+                    <div class="post-body text-sm text-gray-700 mt-2">This is a preview of how posts will look with your custom CSS applied. The styles you write will affect the real page.</div>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Comment preview -->
+              <div class="bg-white rounded-lg border border-gray-200 p-4">
+                <div class="text-xs text-gray-500 mb-2">Comments</div>
+                <div class="comment-body text-sm text-gray-700 pl-3 border-l-2 border-primary/30 comment-thread-line">
+                  <div class="text-xs text-gray-500 mb-1"><span class="text-primary font-medium">u/commenter</span> &middot; 1h ago</div>
+                  This is an example comment to preview your CSS changes.
+                </div>
+              </div>
+
+              <!-- Sidebar preview -->
+              <div class="sidebar bg-white rounded-lg border border-gray-200 p-4">
+                <div class="text-sm font-medium text-gray-900 mb-2">Sidebar</div>
+                <div class="text-xs text-gray-500">
+                  <a href="#" class="text-primary hover:underline">Board Rules</a> &middot;
+                  <a href="#" class="text-primary hover:underline">Wiki</a> &middot;
+                  <a href="#" class="text-primary hover:underline">Moderators</a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Inject preview CSS -->
+        <Teleport to="head">
+          <component :is="'style'" v-if="showPreview" id="tb-css-preview">
+            {{ previewCss }}
+          </component>
+        </Teleport>
+      </div>
+
+      <!-- ============================================ -->
+      <!-- SAVE BAR -->
+      <!-- ============================================ -->
+      <div class="flex items-center justify-between pt-6 mt-6 border-t border-gray-200">
+        <div class="text-sm text-gray-500">
+          <template v-if="cssEnabled && cssCode">
+            CSS will be injected into every page for all visitors.
+          </template>
+          <template v-else-if="!cssEnabled && cssCode">
+            CSS is saved but disabled. Enable it with the toggle above.
+          </template>
+          <template v-else>
+            No custom CSS configured.
+          </template>
+        </div>
+        <button
+          class="button primary"
+          :disabled="saving || (!validation.valid && !!cssCode)"
+          @click="saveCss"
+        >
+          {{ saving ? 'Saving...' : 'Save Custom CSS' }}
+        </button>
+      </div>
+
+      <!-- ============================================ -->
+      <!-- HELP / CASCADE EXPLANATION -->
+      <!-- ============================================ -->
+      <div class="mt-8 rounded-lg bg-gray-50 border border-gray-200 p-5">
+        <h3 class="text-sm font-semibold text-gray-900 mb-3">How CSS Cascading Works</h3>
+        <div class="text-sm text-gray-600 space-y-2">
+          <p>Custom CSS is applied in layers, with later layers overriding earlier ones:</p>
+          <ol class="list-decimal ml-5 space-y-1">
+            <li><strong>Default Theme</strong> &mdash; The built-in theme (light, dark, ocean, etc.)</li>
+            <li><strong>Site Custom CSS</strong> (this page) &mdash; Applied globally on every page</li>
+            <li><strong>Board Custom CSS</strong> &mdash; Applied only when viewing that specific board, overrides site CSS</li>
+          </ol>
+          <p class="text-gray-500 mt-3">
+            Board moderators with the Appearance permission can add custom CSS for their board via Board Settings &rarr; Appearance.
+          </p>
+        </div>
+      </div>
+    </template>
   </div>
 </template>

--- a/frontend/pages/b/[board].vue
+++ b/frontend/pages/b/[board].vue
@@ -51,6 +51,7 @@ onMounted(async () => {
     <CommonErrorDisplay v-else-if="error" :message="error.message" @retry="fetchBoard(boardName)" />
 
     <template v-else-if="board">
+      <CommonBoardCssInjector :css="board.customCss" />
       <BoardHeader :board="board" :is-subscribed="isSubscribed" @subscribe="subscribe" @unsubscribe="unsubscribe" />
       <BoardTabs
         :board-name="board.name"

--- a/frontend/pages/b/[board]/settings/appearance.vue
+++ b/frontend/pages/b/[board]/settings/appearance.vue
@@ -3,6 +3,8 @@ import { useGraphQL, useGraphQLMutation } from '~/composables/useGraphQL'
 import { useFileUpload } from '~/composables/useFileUpload'
 import { useToast } from '~/composables/useToast'
 import { useAuth } from '~/composables/useAuth'
+import { validateCss, CSS_SNIPPET_CATEGORIES } from '~/utils/css-validator'
+import type { CssSnippet } from '~/utils/css-validator'
 
 definePageMeta({ middleware: 'guards' })
 
@@ -20,18 +22,19 @@ interface BoardData {
   primaryColor: string
   secondaryColor: string
   hoverColor: string
+  customCss: string | null
 }
 
 const BOARD_QUERY = `
   query GetBoard($name: String!) {
-    board(name: $name) { id icon banner primaryColor secondaryColor hoverColor }
+    board(name: $name) { id icon banner primaryColor secondaryColor hoverColor customCss }
   }
 `
 
 const UPDATE_BOARD_SETTINGS = `
   mutation UpdateBoardSettings($input: UpdateBoardSettingsInput!) {
     updateBoardSettings(input: $input) {
-      board { id icon banner primaryColor secondaryColor hoverColor }
+      board { id icon banner primaryColor secondaryColor hoverColor customCss }
     }
   }
 `
@@ -48,6 +51,14 @@ const form = reactive({
   icon: null as string | null,
   banner: null as string | null,
 })
+
+const cssCode = ref('')
+const showCssEditor = ref(false)
+const showCssWizard = ref(false)
+const expandedCategory = ref<string | null>(null)
+
+const cssValidation = computed(() => validateCss(cssCode.value, 25 * 1024))
+const cssCharCount = computed(() => new Blob([cssCode.value]).size)
 
 const iconPreview = ref<string | null>(null)
 const bannerPreview = ref<string | null>(null)
@@ -66,6 +77,10 @@ onMounted(async () => {
   form.hoverColor = board.hoverColor
   form.icon = board.icon
   form.banner = board.banner
+  cssCode.value = board.customCss ?? ''
+  if (board.customCss) {
+    showCssEditor.value = true
+  }
   iconPreview.value = board.icon
   bannerPreview.value = board.banner
 })
@@ -108,8 +123,27 @@ function removeBanner () {
   pendingBannerFile.value = null
 }
 
+function insertSnippet (snippet: CssSnippet) {
+  if (cssCode.value && !cssCode.value.endsWith('\n')) {
+    cssCode.value += '\n'
+  }
+  cssCode.value += `\n/* ${snippet.name} */\n${snippet.css}\n`
+  showCssWizard.value = false
+  showCssEditor.value = true
+  toast.success(`Inserted: ${snippet.name}`)
+}
+
+function toggleCategory (name: string) {
+  expandedCategory.value = expandedCategory.value === name ? null : name
+}
+
 async function saveSettings () {
   if (!boardId.value) return
+
+  if (cssCode.value && !cssValidation.value.valid) {
+    toast.error('Please fix CSS errors before saving')
+    return
+  }
 
   uploading.value = true
 
@@ -141,6 +175,7 @@ async function saveSettings () {
         hoverColor: form.hoverColor,
         icon: form.icon,
         banner: form.banner,
+        customCss: cssCode.value || '',
       },
     },
   })
@@ -274,6 +309,82 @@ async function saveSettings () {
             >
               Hover
             </span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Custom CSS section -->
+      <div class="border-t border-gray-200 pt-6">
+        <div class="flex items-center justify-between mb-3">
+          <div>
+            <h3 class="text-sm font-medium text-gray-900">Custom CSS</h3>
+            <p class="text-xs text-gray-500 mt-0.5">Add custom styles that apply only to this board. Overrides site-level CSS.</p>
+          </div>
+          <div class="flex gap-2">
+            <button
+              v-if="!showCssWizard"
+              type="button"
+              class="button white button-sm"
+              @click="showCssWizard = true; showCssEditor = true"
+            >
+              Style Wizard
+            </button>
+            <button
+              type="button"
+              class="button white button-sm"
+              @click="showCssEditor = !showCssEditor"
+            >
+              {{ showCssEditor ? 'Hide Editor' : 'Show Editor' }}
+            </button>
+          </div>
+        </div>
+
+        <!-- CSS Wizard (compact version) -->
+        <div v-if="showCssWizard" class="mb-4 border border-gray-200 rounded-lg overflow-hidden">
+          <div class="px-3 py-2 bg-gray-50 border-b border-gray-200 flex items-center justify-between">
+            <span class="text-xs font-medium text-gray-700">Quick Snippets</span>
+            <button type="button" class="text-xs text-gray-400 hover:text-gray-600" @click="showCssWizard = false">Close</button>
+          </div>
+          <div class="max-h-64 overflow-y-auto divide-y divide-gray-100">
+            <div v-for="category in CSS_SNIPPET_CATEGORIES" :key="category.name">
+              <button
+                type="button"
+                class="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-gray-50 text-xs"
+                @click="toggleCategory(category.name)"
+              >
+                <span class="font-medium text-gray-700 flex-1">{{ category.name }}</span>
+                <span class="text-gray-400" :class="expandedCategory === category.name ? 'rotate-90' : ''">&#9656;</span>
+              </button>
+              <div v-if="expandedCategory === category.name" class="bg-gray-50 divide-y divide-gray-100">
+                <div v-for="snippet in category.snippets" :key="snippet.name" class="px-3 py-2 flex items-center justify-between gap-2">
+                  <div class="min-w-0">
+                    <div class="text-xs font-medium text-gray-800 truncate">{{ snippet.name }}</div>
+                    <div class="text-xs text-gray-500 truncate">{{ snippet.description }}</div>
+                  </div>
+                  <button type="button" class="shrink-0 text-xs text-primary hover:underline" @click="insertSnippet(snippet)">Insert</button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- CSS Editor -->
+        <div v-if="showCssEditor" class="space-y-3">
+          <textarea
+            v-model="cssCode"
+            class="w-full h-48 font-mono text-xs bg-gray-900 text-green-400 rounded-lg p-3 border border-gray-700 focus:border-primary focus:ring-1 focus:ring-primary resize-y leading-relaxed"
+            placeholder="/* Board-specific CSS — overrides site CSS */
+.post-card { border-radius: 12px; }"
+            spellcheck="false"
+          />
+          <div class="flex items-center justify-between text-xs">
+            <div>
+              <span v-if="cssCode && cssValidation.valid" class="text-green-600">&#10003; Valid CSS</span>
+              <span v-else-if="cssCode && !cssValidation.valid" class="text-red-600">
+                &#10007; {{ cssValidation.errors[0] }}
+              </span>
+            </div>
+            <span class="text-gray-400">{{ (cssCharCount / 1024).toFixed(1) }} KB / 25 KB</span>
           </div>
         </div>
       </div>

--- a/frontend/plugins/theme.client.ts
+++ b/frontend/plugins/theme.client.ts
@@ -53,6 +53,24 @@ export default defineNuxtPlugin(() => {
     }
   }
 
+  // Custom CSS injection
+  let siteStyleEl: HTMLStyleElement | null = null
+
+  function applySiteCustomCss () {
+    if (siteStore.customCssEnabled && siteStore.customCss) {
+      if (!siteStyleEl) {
+        siteStyleEl = document.createElement('style')
+        siteStyleEl.id = 'tb-site-custom-css'
+        siteStyleEl.setAttribute('data-source', 'site-admin')
+        document.head.appendChild(siteStyleEl)
+      }
+      siteStyleEl.textContent = siteStore.customCss
+    } else if (siteStyleEl) {
+      siteStyleEl.textContent = ''
+    }
+  }
+
   // Apply on load and watch for changes
   watch(() => [siteStore.primaryColor, siteStore.secondaryColor, siteStore.hoverColor], applyThemeColors, { immediate: true })
+  watch(() => [siteStore.customCss, siteStore.customCssEnabled], applySiteCustomCss, { immediate: true })
 })

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -345,6 +345,7 @@ type Board {
   excludeFromAll: Boolean!
   publicBanReason: String
   wikiEnabled: Boolean!
+  customCss: String
   createdAt: String!
   updatedAt: String!
   subscribers: Int!
@@ -428,6 +429,8 @@ type LocalSite {
   createdAt: String!
   updatedAt: String!
   welcomeMessage: String
+  customCss: String
+  customCssEnabled: Boolean!
 }
 
 type SiteStats {
@@ -701,6 +704,7 @@ input UpdateBoardSettingsInput {
   icon: String
   banner: String
   wikiEnabled: Boolean
+  customCss: String
 }
 
 input UpdateSettingsInput {
@@ -759,6 +763,8 @@ input UpdateSiteConfigInput {
   filteredWords: String
   linkFilterEnabled: Boolean
   bannedDomains: String
+  customCss: String
+  customCssEnabled: Boolean
 }
 
 input BanUserInput {

--- a/frontend/stores/site.ts
+++ b/frontend/stores/site.ts
@@ -35,6 +35,10 @@ export const useSiteStore = defineStore('site', () => {
   const hoverColor = computed(() => site.value?.hoverColor ?? null)
   const defaultTheme = computed(() => site.value?.defaultTheme ?? 'light')
 
+  // Custom CSS
+  const customCss = computed(() => site.value?.customCss ?? null)
+  const customCssEnabled = computed(() => site.value?.customCssEnabled ?? false)
+
   function setSite (newSite: LocalSite): void {
     site.value = newSite
     loaded.value = true
@@ -63,6 +67,8 @@ export const useSiteStore = defineStore('site', () => {
     secondaryColor,
     hoverColor,
     defaultTheme,
+    customCss,
+    customCssEnabled,
     setSite,
     clearSite,
   }

--- a/frontend/types/generated.ts
+++ b/frontend/types/generated.ts
@@ -102,6 +102,7 @@ export type Board = {
   usersActiveMonth: Scalars['Int']['output'];
   usersActiveWeek: Scalars['Int']['output'];
   wikiEnabled: Scalars['Boolean']['output'];
+  customCss?: Maybe<Scalars['String']['output']>;
 };
 
 export type BoardBanResponse = {
@@ -472,6 +473,8 @@ export type LocalSite = {
   updatedAt: Scalars['String']['output'];
   welcomeMessage?: Maybe<Scalars['String']['output']>;
   wordFilterEnabled: Scalars['Boolean']['output'];
+  customCss?: Maybe<Scalars['String']['output']>;
+  customCssEnabled: Scalars['Boolean']['output'];
 };
 
 export type MarkNotificationsReadResponse = {
@@ -1626,6 +1629,7 @@ export type UpdateBoardSettingsInput = {
   sidebar?: InputMaybe<Scalars['String']['input']>;
   title?: InputMaybe<Scalars['String']['input']>;
   wikiEnabled?: InputMaybe<Scalars['Boolean']['input']>;
+  customCss?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type UpdateBoardSettingsResponse = {
@@ -1739,6 +1743,8 @@ export type UpdateSiteConfigInput = {
   secondaryColor?: InputMaybe<Scalars['String']['input']>;
   welcomeMessage?: InputMaybe<Scalars['String']['input']>;
   wordFilterEnabled?: InputMaybe<Scalars['Boolean']['input']>;
+  customCss?: InputMaybe<Scalars['String']['input']>;
+  customCssEnabled?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type User = {

--- a/frontend/utils/css-validator.ts
+++ b/frontend/utils/css-validator.ts
@@ -1,0 +1,315 @@
+/**
+ * Client-side CSS validation — mirrors the backend sanitizer rules.
+ * Used for instant feedback in the CSS editor before submitting.
+ */
+
+export interface CssValidationResult {
+  valid: boolean
+  errors: string[]
+  warnings: string[]
+}
+
+const DANGEROUS_PATTERNS: Array<{ pattern: RegExp; message: string }> = [
+  { pattern: /expression\s*\(/i, message: 'CSS expressions are not allowed (XSS risk)' },
+  { pattern: /javascript\s*:/i, message: 'JavaScript protocol is not allowed' },
+  { pattern: /vbscript\s*:/i, message: 'VBScript protocol is not allowed' },
+  { pattern: /behavior\s*:/i, message: 'IE behavior property is not allowed' },
+  { pattern: /-moz-binding\s*:/i, message: 'Mozilla binding property is not allowed' },
+  { pattern: /@import/i, message: '@import is not allowed — all styles must be inline' },
+  { pattern: /@charset/i, message: '@charset is not allowed' },
+  { pattern: /@namespace/i, message: '@namespace is not allowed' },
+  { pattern: /url\s*\(/i, message: 'url() is not allowed — external resources cannot be loaded' },
+  { pattern: /<\s*\/?(?:script|style|link|meta|iframe)/i, message: 'HTML tags are not allowed in CSS' },
+]
+
+const BLOCKED_VALUES: Array<{ pattern: RegExp; message: string }> = [
+  { pattern: /position\s*:\s*(fixed|sticky)/i, message: 'position: fixed/sticky is not allowed — it can overlay navigation' },
+  { pattern: /z-index\s*:\s*\d{5,}/i, message: 'Very high z-index values (5+ digits) are not allowed' },
+]
+
+export function validateCss (css: string, maxBytes: number = 50 * 1024): CssValidationResult {
+  const errors: string[] = []
+  const warnings: string[] = []
+
+  if (!css.trim()) {
+    return { valid: true, errors, warnings }
+  }
+
+  if (new Blob([css]).size > maxBytes) {
+    errors.push(`CSS exceeds maximum size of ${Math.round(maxBytes / 1024)} KB`)
+  }
+
+  for (const { pattern, message } of DANGEROUS_PATTERNS) {
+    if (pattern.test(css)) {
+      errors.push(message)
+    }
+  }
+
+  for (const { pattern, message } of BLOCKED_VALUES) {
+    if (pattern.test(css)) {
+      warnings.push(message)
+    }
+  }
+
+  // Check balanced braces
+  const open = (css.match(/\{/g) || []).length
+  const close = (css.match(/\}/g) || []).length
+  if (open !== close) {
+    errors.push(`Unbalanced braces: ${open} opening vs ${close} closing`)
+  }
+
+  return { valid: errors.length === 0, errors, warnings }
+}
+
+/**
+ * CSS snippet presets that users can insert with one click.
+ * Grouped by category for the wizard UI.
+ */
+export interface CssSnippet {
+  name: string
+  description: string
+  css: string
+}
+
+export interface CssSnippetCategory {
+  name: string
+  icon: string
+  snippets: CssSnippet[]
+}
+
+export const CSS_SNIPPET_CATEGORIES: CssSnippetCategory[] = [
+  {
+    name: 'Cards & Posts',
+    icon: 'rectangle-stack',
+    snippets: [
+      {
+        name: 'Rounded post cards',
+        description: 'Add rounded corners and subtle shadow to post cards',
+        css: `.post-card {
+  border-radius: 12px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+  overflow: hidden;
+}`,
+      },
+      {
+        name: 'Card hover effect',
+        description: 'Lift cards slightly on hover',
+        css: `.post-card {
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+.post-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}`,
+      },
+      {
+        name: 'Bordered cards',
+        description: 'Add a colored left border to post cards',
+        css: `.post-card {
+  border-left: 3px solid rgb(var(--color-primary));
+  border-radius: 0 8px 8px 0;
+}`,
+      },
+    ],
+  },
+  {
+    name: 'Typography',
+    icon: 'font',
+    snippets: [
+      {
+        name: 'Larger post titles',
+        description: 'Make post titles more prominent',
+        css: `.post-title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}`,
+      },
+      {
+        name: 'Serif headings',
+        description: 'Use serif font for headings (elegant look)',
+        css: `h1, h2, h3, .post-title {
+  font-family: Georgia, 'Times New Roman', serif;
+}`,
+      },
+      {
+        name: 'Compact text',
+        description: 'Tighter line spacing for denser content',
+        css: `.post-body, .comment-body {
+  line-height: 1.5;
+  font-size: 0.9rem;
+}`,
+      },
+    ],
+  },
+  {
+    name: 'Colors & Backgrounds',
+    icon: 'palette',
+    snippets: [
+      {
+        name: 'Subtle page background',
+        description: 'Add a slight color tint to the page background',
+        css: `body {
+  background-color: #f8f9fa;
+}`,
+      },
+      {
+        name: 'Dark sidebar',
+        description: 'Give the sidebar a dark background',
+        css: `.sidebar {
+  background-color: #1f2937;
+  color: #e5e7eb;
+  border-radius: 12px;
+  padding: 1rem;
+}
+.sidebar a { color: #93c5fd; }
+.sidebar a:hover { color: #bfdbfe; }`,
+      },
+      {
+        name: 'Gradient header',
+        description: 'Add a gradient to the site header',
+        css: `.app-header {
+  background: linear-gradient(135deg, rgb(var(--color-primary)), rgb(var(--color-primary-hover)));
+}`,
+      },
+    ],
+  },
+  {
+    name: 'Layout & Spacing',
+    icon: 'layout',
+    snippets: [
+      {
+        name: 'Wider content area',
+        description: 'Increase the max width of the main content',
+        css: `.max-w-8xl {
+  max-width: 96rem;
+}`,
+      },
+      {
+        name: 'Compact spacing',
+        description: 'Reduce spacing between posts',
+        css: `.post-list > * + * {
+  margin-top: 0.5rem;
+}`,
+      },
+      {
+        name: 'Hide sidebar on all pages',
+        description: 'Remove the sidebar entirely',
+        css: `.sidebar-container {
+  display: none;
+}
+main {
+  max-width: 100%;
+}`,
+      },
+    ],
+  },
+  {
+    name: 'Buttons & Links',
+    icon: 'cursor-click',
+    snippets: [
+      {
+        name: 'Pill-shaped buttons',
+        description: 'Make all buttons fully rounded',
+        css: `.button, button[type="submit"] {
+  border-radius: 9999px;
+}`,
+      },
+      {
+        name: 'Underline links on hover',
+        description: 'Add underline effect to links on hover',
+        css: `a:not(.button):not(.no-underline) {
+  text-decoration: none;
+  transition: text-decoration 0.15s;
+}
+a:not(.button):not(.no-underline):hover {
+  text-decoration: underline;
+}`,
+      },
+    ],
+  },
+  {
+    name: 'Comments',
+    icon: 'chat-bubble',
+    snippets: [
+      {
+        name: 'Colorful thread lines',
+        description: 'Color-code nested comment thread lines',
+        css: `.comment-thread-line { border-left-color: rgb(var(--color-primary) / 0.3); }
+.comment-depth-1 .comment-thread-line { border-left-color: #3b82f6; }
+.comment-depth-2 .comment-thread-line { border-left-color: #8b5cf6; }
+.comment-depth-3 .comment-thread-line { border-left-color: #ec4899; }
+.comment-depth-4 .comment-thread-line { border-left-color: #f59e0b; }
+.comment-depth-5 .comment-thread-line { border-left-color: #10b981; }`,
+      },
+      {
+        name: 'Rounded comment bubbles',
+        description: 'Style comments as chat-like bubbles',
+        css: `.comment-body {
+  background: #f3f4f6;
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+  margin-top: 0.25rem;
+}`,
+      },
+    ],
+  },
+  {
+    name: 'Animations',
+    icon: 'sparkles',
+    snippets: [
+      {
+        name: 'Fade-in posts',
+        description: 'Posts fade in when they appear',
+        css: `@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+.post-card {
+  animation: fadeIn 0.3s ease forwards;
+}`,
+      },
+      {
+        name: 'Smooth vote animation',
+        description: 'Add a pop effect when voting',
+        css: `.vote-button:active {
+  transform: scale(1.3);
+  transition: transform 0.1s ease;
+}
+.vote-button {
+  transition: transform 0.15s ease;
+}`,
+      },
+    ],
+  },
+  {
+    name: 'Dark Mode Tweaks',
+    icon: 'moon',
+    snippets: [
+      {
+        name: 'Custom dark mode colors',
+        description: 'Adjust dark mode background and text colors',
+        css: `body.dark {
+  background-color: #0f172a;
+  color: #e2e8f0;
+}
+body.dark .post-card {
+  background-color: #1e293b;
+  border-color: #334155;
+}`,
+      },
+      {
+        name: 'OLED dark mode',
+        description: 'True black background for OLED screens',
+        css: `body.dark {
+  background-color: #000000;
+}
+body.dark .post-card,
+body.dark .sidebar {
+  background-color: #111111;
+  border-color: #222222;
+}`,
+      },
+    ],
+  },
+]

--- a/migrations/2026-03-27-000020_custom_css/down.sql
+++ b/migrations/2026-03-27-000020_custom_css/down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE boards DROP COLUMN IF EXISTS custom_css;
+
+ALTER TABLE site
+    DROP COLUMN IF EXISTS custom_css_enabled,
+    DROP COLUMN IF EXISTS custom_css;

--- a/migrations/2026-03-27-000020_custom_css/up.sql
+++ b/migrations/2026-03-27-000020_custom_css/up.sql
@@ -1,0 +1,9 @@
+-- Add custom CSS support to site and boards tables.
+-- Site custom CSS applies globally; board custom CSS overrides within that board's pages.
+
+ALTER TABLE site
+    ADD COLUMN custom_css TEXT,
+    ADD COLUMN custom_css_enabled BOOLEAN NOT NULL DEFAULT false;
+
+ALTER TABLE boards
+    ADD COLUMN custom_css TEXT;

--- a/schema.graphql
+++ b/schema.graphql
@@ -394,6 +394,7 @@ type Board {
   usersActiveHalfYear: Int!
   isSubscribed: Boolean!
   sectionConfig: Int!
+  customCss: String
 }
 
 type User {
@@ -468,6 +469,8 @@ type LocalSite {
   createdAt: String!
   updatedAt: String!
   welcomeMessage: String
+  customCss: String
+  customCssEnabled: Boolean!
 }
 
 type SiteStats {
@@ -749,6 +752,7 @@ input UpdateBoardSettingsInput {
   sectionOrder: String
   defaultSection: String
   wikiEnabled: Boolean
+  customCss: String
 }
 
 input UpdateSettingsInput {
@@ -813,6 +817,8 @@ input UpdateSiteConfigInput {
   linkFilterEnabled: Boolean
   bannedDomains: String
   registrationMode: String
+  customCss: String
+  customCssEnabled: Boolean
 }
 
 input BanUserInput {


### PR DESCRIPTION
…izard

Add full custom CSS support with two tiers:
- Site-level CSS (admin panel): applies globally, can be enabled/disabled
- Board-level CSS (board settings): applies per-board, overrides site CSS

Backend:
- Migration adds custom_css columns to site and boards tables
- CSS sanitizer blocks XSS vectors (@import, url(), expression(), etc.)
- Size limits: 50KB site, 25KB board
- Brace balancing validation prevents broken pages
- GraphQL types and mutations updated for both site and board

Frontend:
- Admin CSS page with three tabs: Style Wizard, CSS Editor, Live Preview
- 8 snippet categories with 20+ ready-to-use CSS presets
- Real-time client-side validation mirroring backend rules
- Board appearance page gets integrated CSS editor with wizard
- Theme plugin injects site CSS globally via style element
- BoardCssInjector component handles board CSS lifecycle
- Proper cascade: theme -> site CSS -> board CSS