### PR TITLE
fix(media): proxy media requests through Nuxt for bare-metal local dev

### DIFF
--- a/frontend/server/api/graphql-upload.ts
+++ b/frontend/server/api/graphql-upload.ts
@@ -47,13 +47,13 @@ export default defineEventHandler(async (event) => {
         // Rebuild form data for retry (original may have been consumed)
         const retryFormData = buildFormData(parts)
         const retry = await forwardUpload(gqlEndpoint, retryFormData, newAccessToken)
-        return retry.data
+        return rewriteMediaUrls(retry.data, config.public.domain as string)
       }
 
       clearAuthCookies(event)
     }
 
-    return data
+    return rewriteMediaUrls(data, config.public.domain as string)
   } catch (err) {
     throw createError({
       statusCode: 500,
@@ -61,6 +61,18 @@ export default defineEventHandler(async (event) => {
     })
   }
 })
+
+/**
+ * Rewrite absolute media URLs to relative paths so they resolve correctly
+ * in all deployment configurations (with or without nginx).
+ */
+function rewriteMediaUrls (data: unknown, domain: string): unknown {
+  if (!data) return data
+  const json = JSON.stringify(data)
+  const escaped = domain.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const pattern = new RegExp(`https?://${escaped}(?::\\d+)?/media/`, 'g')
+  return JSON.parse(json.replace(pattern, '/media/'))
+}
 
 function buildFormData (parts: { name?: string; filename?: string; data: Buffer; type?: string }[]): FormData {
   const formData = new FormData()

--- a/frontend/server/api/graphql.ts
+++ b/frontend/server/api/graphql.ts
@@ -54,15 +54,34 @@ export default defineEventHandler(async (event) => {
     if (newAccessToken) {
       // Retry original request with the new token
       const retry = await forwardGraphQLRequest(gqlEndpoint, body, newAccessToken)
-      return retry.data
+      return rewriteMediaUrls(retry.data, config.public.domain as string)
     }
 
     // Refresh failed — clear cookies and return the original error
     clearAuthCookies(event)
   }
 
-  return result.data
+  return rewriteMediaUrls(result.data, config.public.domain as string)
 })
+
+/**
+ * Rewrite absolute media URLs from the backend into relative paths.
+ *
+ * The backend stores URLs like http://localhost/media/file.jpg using
+ * get_protocol_and_hostname(), which omits the port. In production nginx
+ * handles /media/ on port 80/443, but in bare-metal local dev (no nginx)
+ * nothing serves on those ports. Converting to relative /media/ paths lets
+ * the browser resolve them against the current origin, where the Nuxt
+ * server route proxy forwards them to the backend.
+ */
+function rewriteMediaUrls (data: GraphQLResponse, domain: string): GraphQLResponse {
+  if (!data) return data
+  const json = JSON.stringify(data)
+  const escaped = domain.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const pattern = new RegExp(`https?://${escaped}(?::\\d+)?/media/`, 'g')
+  const rewritten = json.replace(pattern, '/media/')
+  return JSON.parse(rewritten)
+}
 
 interface ForwardResult {
   httpStatus: number

--- a/frontend/server/routes/media/[...].ts
+++ b/frontend/server/routes/media/[...].ts
@@ -1,0 +1,87 @@
+import { defineEventHandler, getRequestURL, setResponseHeader, sendStream, createError } from 'h3'
+import { Readable } from 'node:stream'
+
+/**
+ * Proxy for /media/* requests to the backend.
+ *
+ * In production, nginx serves media files directly. In local bare-metal
+ * development (no nginx), this route forwards media requests to the Rust
+ * backend so that URLs like /media/avatars/foo.jpg resolve correctly.
+ */
+export default defineEventHandler(async (event) => {
+  const config = useRuntimeConfig()
+  const backendUrl = config.backendUrl
+
+  // Reconstruct the path from the original request URL
+  const requestUrl = getRequestURL(event)
+  const mediaPath = requestUrl.pathname // e.g. /media/avatars/foo.jpg
+
+  const targetUrl = `${backendUrl}${mediaPath}`
+
+  try {
+    const response = await fetch(targetUrl, {
+      headers: {
+        // Forward range requests for video seeking
+        ...(event.node.req.headers.range
+          ? { Range: event.node.req.headers.range }
+          : {}),
+      },
+    })
+
+    if (!response.ok && response.status !== 206) {
+      throw createError({
+        statusCode: response.status,
+        statusMessage: response.statusText,
+      })
+    }
+
+    // Forward relevant headers
+    const headersToForward = [
+      'content-type',
+      'content-length',
+      'content-range',
+      'accept-ranges',
+      'cache-control',
+      'etag',
+      'last-modified',
+    ]
+
+    for (const header of headersToForward) {
+      const value = response.headers.get(header)
+      if (value) {
+        setResponseHeader(event, header, value)
+      }
+    }
+
+    // Set status for partial content (range requests)
+    if (response.status === 206) {
+      event.node.res.statusCode = 206
+    }
+
+    if (response.body) {
+      // Convert web ReadableStream to Node.js Readable
+      const reader = response.body.getReader()
+      const nodeStream = new Readable({
+        async read() {
+          const { done, value } = await reader.read()
+          if (done) {
+            this.push(null)
+          } else {
+            this.push(Buffer.from(value))
+          }
+        },
+      })
+      return sendStream(event, nodeStream)
+    }
+
+    return ''
+  } catch (err: unknown) {
+    if ((err as { statusCode?: number }).statusCode) {
+      throw err
+    }
+    throw createError({
+      statusCode: 502,
+      statusMessage: 'Failed to fetch media from backend',
+    })
+  }
+})


### PR DESCRIPTION
In bare-metal local development (no nginx), media URLs returned by the backend resolve to http://localhost/media/... which has nothing serving on port 80. This adds:

1. A Nuxt server route at /media/[...] that proxies media requests to the backend (port 8536), supporting range requests for video.
2. URL rewriting in both BFF GraphQL proxies to convert absolute media URLs to relative /media/ paths, so the browser resolves them against the current origin (localhost:3000 in dev).

In production with nginx, the proxy route is unused since nginx handles /media/ directly.