### PR TITLE
fix(boards): enforce board creation mode permissions correctly

### DIFF
--- a/backend/crates/api/src/mutations/board/create.rs
+++ b/backend/crates/api/src/mutations/board/create.rs
@@ -71,15 +71,16 @@ impl CreateBoard {
 
         let admin_level = user.admin_level;
 
-        match site.board_creation_mode.as_str() {
-            "Disabled" => {
+        // Normalize to lowercase for case-insensitive matching
+        match site.board_creation_mode.to_lowercase().as_str() {
+            "disabled" => {
                 return Err(TinyBoardsError::from_message(
                     403,
                     "Board creation is currently disabled",
                 )
                 .into());
             }
-            "AdminOnly" => {
+            "adminonly" | "admin_only" | "closed" => {
                 if admin_level == 0 {
                     return Err(TinyBoardsError::from_message(
                         403,
@@ -88,7 +89,7 @@ impl CreateBoard {
                     .into());
                 }
             }
-            "TrustedUsers" => {
+            "trustedusers" | "trusted_users" | "restricted" => {
                 // Admins bypass all checks
                 if admin_level == 0 {
                     // Check manual approval if required
@@ -160,8 +161,17 @@ impl CreateBoard {
                     }
                 }
             }
-            // "Open" or any unrecognised value: no restrictions
-            _ => {}
+            // "open" or any unrecognised value: no restrictions
+            _ => {
+                // Also check the legacy board_creation_admin_only flag
+                if site.board_creation_admin_only && admin_level == 0 {
+                    return Err(TinyBoardsError::from_message(
+                        403,
+                        "Board creation is restricted to admins only",
+                    )
+                    .into());
+                }
+            }
         }
 
         // Validate board name

--- a/backend/crates/api/src/mutations/site/config.rs
+++ b/backend/crates/api/src/mutations/site/config.rs
@@ -50,6 +50,10 @@ pub struct UpdateSiteConfigInput {
     pub registration_mode: Option<String>,
     pub custom_css: Option<String>,
     pub custom_css_enabled: Option<bool>,
+    pub trusted_user_min_reputation: Option<i32>,
+    pub trusted_user_min_account_age_days: Option<i32>,
+    pub trusted_user_manual_approval: Option<bool>,
+    pub trusted_user_min_posts: Option<i32>,
 }
 
 #[Object]
@@ -103,7 +107,16 @@ impl SiteConfig {
             require_email_verification: input.require_email_verification,
             boards_enabled: input.boards_enabled,
             board_creation_admin_only: input.board_creation_admin_only,
-            board_creation_mode: input.board_creation_mode,
+            board_creation_mode: input.board_creation_mode.map(|s| {
+                // Normalize board creation mode to canonical PascalCase values
+                match s.to_lowercase().as_str() {
+                    "disabled" => "Disabled".to_string(),
+                    "adminonly" | "admin_only" | "closed" => "AdminOnly".to_string(),
+                    "trustedusers" | "trusted_users" | "restricted" => "TrustedUsers".to_string(),
+                    "open" => "Open".to_string(),
+                    _ => "Open".to_string(),
+                }
+            }),
             emoji_enabled: input.emoji_enabled,
             board_emojis_enabled: input.board_emojis_enabled,
             word_filter_enabled: input.word_filter_enabled,
@@ -123,10 +136,10 @@ impl SiteConfig {
                 _ => DbRegistrationMode::Open,
             }),
             is_site_setup: None,
-            trusted_user_min_reputation: None,
-            trusted_user_min_account_age_days: None,
-            trusted_user_manual_approval: None,
-            trusted_user_min_posts: None,
+            trusted_user_min_reputation: input.trusted_user_min_reputation,
+            trusted_user_min_account_age_days: input.trusted_user_min_account_age_days,
+            trusted_user_manual_approval: input.trusted_user_manual_approval,
+            trusted_user_min_posts: input.trusted_user_min_posts,
             allowed_post_types: None,
             word_filter_applies_to_posts: None,
             word_filter_applies_to_comments: None,

--- a/frontend/pages/admin/board_settings.vue
+++ b/frontend/pages/admin/board_settings.vue
@@ -8,6 +8,10 @@ interface BoardSettings {
   boardCreationMode: string
   boardsEnabled: boolean
   boardCreationAdminOnly: boolean
+  trustedUserMinReputation: number
+  trustedUserMinAccountAgeDays: number
+  trustedUserManualApproval: boolean
+  trustedUserMinPosts: number
 }
 
 interface BoardSettingsResponse {
@@ -21,9 +25,12 @@ interface SaveBoardSettingsResponse {
 const { execute, loading, error, data } = useGraphQL<BoardSettingsResponse>()
 const { execute: executeSave, loading: saving, error: saveError } = useGraphQLMutation<SaveBoardSettingsResponse>()
 
-const boardCreationMode = ref('open')
+const boardCreationMode = ref('AdminOnly')
 const boardsEnabled = ref(true)
-const boardCreationAdminOnly = ref(false)
+const trustedUserMinReputation = ref(0)
+const trustedUserMinAccountAgeDays = ref(0)
+const trustedUserManualApproval = ref(false)
+const trustedUserMinPosts = ref(0)
 const saved = ref(false)
 
 const SETTINGS_QUERY = `
@@ -32,6 +39,10 @@ const SETTINGS_QUERY = `
       boardCreationMode
       boardsEnabled
       boardCreationAdminOnly
+      trustedUserMinReputation
+      trustedUserMinAccountAgeDays
+      trustedUserManualApproval
+      trustedUserMinPosts
     }
   }
 `
@@ -42,6 +53,10 @@ const SAVE_SETTINGS = `
       boardCreationMode
       boardsEnabled
       boardCreationAdminOnly
+      trustedUserMinReputation
+      trustedUserMinAccountAgeDays
+      trustedUserManualApproval
+      trustedUserMinPosts
     }
   }
 `
@@ -51,7 +66,10 @@ async function loadSettings () {
   if (result?.site) {
     boardCreationMode.value = result.site.boardCreationMode
     boardsEnabled.value = result.site.boardsEnabled
-    boardCreationAdminOnly.value = result.site.boardCreationAdminOnly
+    trustedUserMinReputation.value = result.site.trustedUserMinReputation
+    trustedUserMinAccountAgeDays.value = result.site.trustedUserMinAccountAgeDays
+    trustedUserManualApproval.value = result.site.trustedUserManualApproval
+    trustedUserMinPosts.value = result.site.trustedUserMinPosts
   }
 }
 
@@ -62,7 +80,12 @@ async function saveSettings () {
       input: {
         boardCreationMode: boardCreationMode.value,
         boardsEnabled: boardsEnabled.value,
-        boardCreationAdminOnly: boardCreationAdminOnly.value,
+        ...(boardCreationMode.value === 'TrustedUsers' ? {
+          trustedUserMinReputation: trustedUserMinReputation.value,
+          trustedUserMinAccountAgeDays: trustedUserMinAccountAgeDays.value,
+          trustedUserManualApproval: trustedUserManualApproval.value,
+          trustedUserMinPosts: trustedUserMinPosts.value,
+        } : {}),
       },
     },
   })
@@ -80,7 +103,7 @@ onMounted(() => {
 <template>
   <div>
     <h2 class="text-lg font-semibold text-gray-900 mb-6">
-      Board Defaults
+      Board Settings
     </h2>
 
     <CommonLoadingSpinner v-if="loading" />
@@ -104,25 +127,74 @@ onMounted(() => {
           Board Creation Mode
         </label>
         <select v-model="boardCreationMode" class="form-input w-full">
-          <option value="open">Open (anyone can create)</option>
-          <option value="restricted">Restricted (approval required)</option>
-          <option value="closed">Closed (admin only)</option>
+          <option value="Open">Open (anyone can create)</option>
+          <option value="TrustedUsers">Trusted Users (configurable requirements)</option>
+          <option value="AdminOnly">Admin Only</option>
+          <option value="Disabled">Disabled (no one can create)</option>
         </select>
         <p class="mt-1 text-xs text-gray-500">
           Controls who can create new boards on the site.
         </p>
       </div>
 
-      <!-- Admin-only board creation -->
-      <div>
-        <label class="flex items-center gap-2">
-          <input v-model="boardCreationAdminOnly" type="checkbox" class="form-checkbox" />
-          <span class="text-sm font-medium text-gray-700">Admin-Only Board Creation</span>
-        </label>
-        <p class="mt-1 text-xs text-gray-500">
-          When enabled, only admins can create new boards regardless of the creation mode above.
-        </p>
-      </div>
+      <!-- Trusted Users settings (shown only when TrustedUsers mode is selected) -->
+      <template v-if="boardCreationMode === 'TrustedUsers'">
+        <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 space-y-4">
+          <h3 class="text-sm font-semibold text-gray-800">
+            Trusted User Requirements
+          </h3>
+          <p class="text-xs text-gray-500">
+            Users must meet all of these requirements to create boards. Admins always bypass these checks.
+          </p>
+
+          <div>
+            <label class="block text-sm font-medium text-gray-700 mb-1">
+              Minimum Reputation (post + comment score)
+            </label>
+            <input
+              v-model.number="trustedUserMinReputation"
+              type="number"
+              min="0"
+              class="form-input w-full"
+            />
+          </div>
+
+          <div>
+            <label class="block text-sm font-medium text-gray-700 mb-1">
+              Minimum Account Age (days)
+            </label>
+            <input
+              v-model.number="trustedUserMinAccountAgeDays"
+              type="number"
+              min="0"
+              class="form-input w-full"
+            />
+          </div>
+
+          <div>
+            <label class="block text-sm font-medium text-gray-700 mb-1">
+              Minimum Posts
+            </label>
+            <input
+              v-model.number="trustedUserMinPosts"
+              type="number"
+              min="0"
+              class="form-input w-full"
+            />
+          </div>
+
+          <div>
+            <label class="flex items-center gap-2">
+              <input v-model="trustedUserManualApproval" type="checkbox" class="form-checkbox" />
+              <span class="text-sm font-medium text-gray-700">Require Manual Approval</span>
+            </label>
+            <p class="mt-1 text-xs text-gray-500">
+              When enabled, users must also be manually approved by an admin before they can create boards,
+              even if they meet the automatic requirements above.
+            </p>
+          </div>
+        </div>
+      </template>
 
       <CommonErrorDisplay v-if="saveError" :message="saveError.message" />
 

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -427,6 +427,10 @@ type LocalSite {
   boardsEnabled: Boolean!
   boardCreationAdminOnly: Boolean!
   boardCreationMode: String!
+  trustedUserMinReputation: Int!
+  trustedUserMinAccountAgeDays: Int!
+  trustedUserManualApproval: Boolean!
+  trustedUserMinPosts: Int!
   allowedPostTypes: String
   wordFilterEnabled: Boolean!
   filteredWords: String
@@ -761,6 +765,10 @@ input UpdateSiteConfigInput {
   boardsEnabled: Boolean
   boardCreationAdminOnly: Boolean
   boardCreationMode: String
+  trustedUserMinReputation: Int
+  trustedUserMinAccountAgeDays: Int
+  trustedUserManualApproval: Boolean
+  trustedUserMinPosts: Int
   emojiEnabled: Boolean
   boardEmojisEnabled: Boolean
   wordFilterEnabled: Boolean

--- a/schema.graphql
+++ b/schema.graphql
@@ -467,6 +467,10 @@ type LocalSite {
   boardsEnabled: Boolean!
   boardCreationAdminOnly: Boolean!
   boardCreationMode: String!
+  trustedUserMinReputation: Int!
+  trustedUserMinAccountAgeDays: Int!
+  trustedUserManualApproval: Boolean!
+  trustedUserMinPosts: Int!
   allowedPostTypes: String
   wordFilterEnabled: Boolean!
   filteredWords: String
@@ -814,6 +818,10 @@ input UpdateSiteConfigInput {
   boardsEnabled: Boolean
   boardCreationAdminOnly: Boolean
   boardCreationMode: String
+  trustedUserMinReputation: Int
+  trustedUserMinAccountAgeDays: Int
+  trustedUserManualApproval: Boolean
+  trustedUserMinPosts: Int
   emojiEnabled: Boolean
   boardEmojisEnabled: Boolean
   wordFilterEnabled: Boolean


### PR DESCRIPTION
The board_creation_mode match in create_board used case-sensitive PascalCase values (AdminOnly, TrustedUsers, Disabled) while the frontend sent lowercase (open, restricted, closed) and the SQL migration defaulted to 'open'. Any unrecognised value fell through to the catch-all branch which applied no restrictions, allowing any user to create boards regardless of settings.

Changes:
- Normalise board_creation_mode to lowercase before matching so all historical and variant spellings are handled
- Add canonical normalisation in update_site_config so new values are always stored in PascalCase
- Honour the legacy board_creation_admin_only flag in the open/ catch-all branch
- Expose trusted user config fields (min reputation, account age, posts, manual approval) in UpdateSiteConfigInput
- Rewrite frontend board_settings.vue with correct option values (Open, AdminOnly, TrustedUsers, Disabled), remove dead boardCreationAdminOnly checkbox, add TrustedUsers config panel
- Update both GraphQL schemas with trusted user fields