### PR TITLE
Remove board mode tags, fix filter pills, and gate Create Board button

### DIFF
--- a/frontend/components/board/BoardCard.vue
+++ b/frontend/components/board/BoardCard.vue
@@ -10,19 +10,13 @@ defineProps<{
   <NuxtLink
     :to="`/b/${board.name}`"
     class="block bg-white border border-gray-200 rounded p-4 hover:border-gray-300 transition-colors no-underline"
+    :class="board.mode === 'forum' ? 'border-l-2 border-l-purple-400' : 'border-l-2 border-l-blue-400'"
   >
     <div class="flex items-center gap-3">
       <CommonAvatar :src="board.icon ?? undefined" :name="board.name" size="md" />
       <div class="flex-1 min-w-0">
-        <h3 class="font-semibold text-gray-900 text-sm truncate flex items-center gap-1.5">
+        <h3 class="font-semibold text-gray-900 text-sm truncate">
           {{ board.title }}
-          <span
-            v-if="board.mode"
-            class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium shrink-0"
-            :class="board.mode === 'forum' ? 'bg-purple-100 text-purple-700' : 'bg-blue-100 text-blue-700'"
-          >
-            {{ board.mode === 'forum' ? '💬 Forum' : '📰 Feed' }}
-          </span>
         </h3>
         <p class="text-xs text-gray-500">
           b/{{ board.name }} &middot; {{ board.subscribers }} members

--- a/frontend/components/board/BoardHeader.vue
+++ b/frontend/components/board/BoardHeader.vue
@@ -38,18 +38,9 @@ const authStore = useAuthStore()
           class="border-2 border-white shadow shrink-0"
         />
 
-        <!-- Name + description + mode badge -->
+        <!-- Name + description -->
         <div class="flex-1 min-w-0">
-          <div class="flex items-center gap-2">
-            <h1 class="text-base sm:text-lg font-bold text-gray-900 truncate">{{ board.title }}</h1>
-            <span
-              v-if="board.mode"
-              class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium shrink-0"
-              :class="board.mode === 'forum' ? 'bg-purple-100 text-purple-700' : 'bg-blue-100 text-blue-700'"
-            >
-              {{ board.mode === 'forum' ? '💬 Forum' : '📰 Feed' }}
-            </span>
-          </div>
+          <h1 class="text-base sm:text-lg font-bold text-gray-900 truncate">{{ board.title }}</h1>
           <p class="text-sm text-gray-500">b/{{ board.name }}</p>
         </div>
 

--- a/frontend/components/board/FeedSidebar.vue
+++ b/frontend/components/board/FeedSidebar.vue
@@ -41,16 +41,6 @@ const siteStore = useSiteStore()
           >
             <CommonAvatar :src="board.icon ?? undefined" :name="board.name" size="xs" />
             <span class="truncate">{{ board.title }}</span>
-            <span
-              v-if="board.mode === 'forum'"
-              class="text-[10px] text-purple-500 shrink-0"
-              title="Forum"
-            >💬</span>
-            <span
-              v-else-if="board.mode === 'feed'"
-              class="text-[10px] text-blue-500 shrink-0"
-              title="Feed"
-            >📰</span>
             <span class="text-xs text-gray-400 ml-auto">{{ board.subscribers }}</span>
           </NuxtLink>
         </li>

--- a/frontend/pages/boards/index.vue
+++ b/frontend/pages/boards/index.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import { useGraphQL } from '~/composables/useGraphQL'
 import { useAuthStore } from '~/stores/auth'
+import { useSiteStore } from '~/stores/site'
 import type { Board } from '~/types/generated'
 
 const authStore = useAuthStore()
+const siteStore = useSiteStore()
 const route = useRoute()
 const router = useRouter()
 
@@ -101,18 +103,9 @@ await fetchBoards()
 
 <template>
   <div class="max-w-4xl mx-auto px-4 py-4">
-    <div class="flex items-center justify-between mb-4">
-      <h1 class="text-lg font-semibold text-gray-900">
-        Board Directory
-      </h1>
-      <NuxtLink
-        v-if="authStore.isLoggedIn"
-        to="/boards/create"
-        class="button button-sm primary no-underline"
-      >
-        Create Board
-      </NuxtLink>
-    </div>
+    <h1 class="text-lg font-semibold text-gray-900 mb-4">
+      Board Directory
+    </h1>
 
     <div class="mb-4 flex flex-col sm:flex-row gap-2">
       <form @submit.prevent="handleSearch" class="flex gap-2 flex-1">
@@ -139,32 +132,41 @@ await fetchBoards()
       </select>
     </div>
 
-    <!-- Mode filter -->
-    <div class="mb-4 flex gap-1">
-      <button
-        type="button"
-        class="px-3 py-1 rounded-full text-xs font-medium transition-colors"
-        :class="modeFilter === 'all' ? 'bg-gray-900 text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'"
-        @click="setModeFilter('all')"
+    <!-- Mode filter + Create Board -->
+    <div class="mb-4 flex items-center justify-between">
+      <div class="flex gap-1">
+        <button
+          type="button"
+          class="px-3 py-1 rounded-full text-xs font-medium transition-colors"
+          :class="modeFilter === 'all' ? 'bg-gray-900 text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'"
+          @click="setModeFilter('all')"
+        >
+          All
+        </button>
+        <button
+          type="button"
+          class="px-3 py-1 rounded-full text-xs font-medium transition-colors"
+          :class="modeFilter === 'feed' ? 'bg-blue-100 text-blue-800 ring-1 ring-blue-300' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'"
+          @click="setModeFilter('feed')"
+        >
+          Feed
+        </button>
+        <button
+          type="button"
+          class="px-3 py-1 rounded-full text-xs font-medium transition-colors"
+          :class="modeFilter === 'forum' ? 'bg-purple-100 text-purple-800 ring-1 ring-purple-300' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'"
+          @click="setModeFilter('forum')"
+        >
+          Forum
+        </button>
+      </div>
+      <NuxtLink
+        v-if="authStore.isLoggedIn && (!siteStore.boardCreationAdminOnly || authStore.isAdmin)"
+        to="/boards/create"
+        class="button button-sm primary no-underline"
       >
-        All
-      </button>
-      <button
-        type="button"
-        class="px-3 py-1 rounded-full text-xs font-medium transition-colors"
-        :class="modeFilter === 'feed' ? 'bg-blue-600 text-white' : 'bg-blue-50 text-blue-700 hover:bg-blue-100'"
-        @click="setModeFilter('feed')"
-      >
-        📰 Feed
-      </button>
-      <button
-        type="button"
-        class="px-3 py-1 rounded-full text-xs font-medium transition-colors"
-        :class="modeFilter === 'forum' ? 'bg-purple-600 text-white' : 'bg-purple-50 text-purple-700 hover:bg-purple-100'"
-        @click="setModeFilter('forum')"
-      >
-        💬 Forum
-      </button>
+        Create Board
+      </NuxtLink>
     </div>
 
     <CommonErrorDisplay v-if="error" :message="error.message" @retry="fetchBoards" />


### PR DESCRIPTION
- Remove Feed/Forum badge tags from BoardCard, BoardHeader, and FeedSidebar
- Differentiate board modes via colored left border on cards instead (blue for feed, purple for forum)
- Fix Feed/Forum filter pill buttons using colored background + ring instead of solid fill that made text illegible
- Move Create Board button next to mode filters and hide it from users without board creation permission