### PR TITLE
fix(frontend): render HTML content in post/comment previews

### DIFF
--- a/frontend/components/notifications/NotificationItem.vue
+++ b/frontend/components/notifications/NotificationItem.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { NotificationActor, NotificationPostContext, NotificationCommentContext, NotificationMessageContext } from '~/composables/useNotifications'
+import { sanitizeHtml } from '~/utils/sanitize'
 
 const props = defineProps<{
   id: string
@@ -43,6 +44,13 @@ const contextText = computed(() => {
   }
   if (props.message) {
     return props.message.body
+  }
+  return null
+})
+
+const contextHtml = computed(() => {
+  if (props.comment?.bodyHTML) {
+    return sanitizeHtml(props.comment.bodyHTML)
   }
   return null
 })
@@ -178,7 +186,8 @@ function handleClick () {
       </p>
 
       <!-- Snippet: comment body or message body -->
-      <p v-if="contextText" class="text-xs text-gray-600 mt-1 line-clamp-2 leading-relaxed">
+      <div v-if="contextHtml" class="text-xs text-gray-600 mt-1 line-clamp-2 leading-relaxed prose prose-xs max-w-none [&>*]:m-0" v-html="contextHtml" />
+      <p v-else-if="contextText" class="text-xs text-gray-600 mt-1 line-clamp-2 leading-relaxed">
         {{ contextText }}
       </p>
 

--- a/frontend/components/post/PostCard.vue
+++ b/frontend/components/post/PostCard.vue
@@ -6,6 +6,7 @@ import { postUrl } from '~/utils/slug'
 import { useGraphQL } from '~/composables/useGraphQL'
 import { useAuthStore } from '~/stores/auth'
 import { useToast } from '~/composables/useToast'
+import { sanitizeHtml } from '~/utils/sanitize'
 
 const props = defineProps<{
   post: Post
@@ -316,12 +317,11 @@ const hasLinkPreview = computed(() => {
           </a>
 
           <!-- Body preview (if text post) -->
-          <p
-            v-if="post.body && !post.url"
-            class="text-sm text-gray-500 line-clamp-2 mt-0.5 leading-relaxed"
-          >
-            {{ post.body }}
-          </p>
+          <div
+            v-if="post.bodyHTML && !post.url"
+            class="text-sm text-gray-500 line-clamp-2 mt-0.5 leading-relaxed prose prose-sm max-w-none [&>*]:m-0"
+            v-html="sanitizeHtml(post.bodyHTML)"
+          />
 
           <!-- Flags -->
           <div v-if="post.isNSFW || post.isLocked" class="flex items-center gap-2 mt-1">

--- a/frontend/composables/useNotifications.ts
+++ b/frontend/composables/useNotifications.ts
@@ -19,6 +19,7 @@ export interface NotificationPostContext {
 export interface NotificationCommentContext {
   id: string
   body: string
+  bodyHTML: string | null
   postId: string
   postTitle: string
   boardName: string
@@ -57,7 +58,7 @@ const NOTIFICATIONS_QUERY = `
       id type isRead createdAt commentId postId messageId
       actor { id name displayName avatar }
       post { id title boardName boardId }
-      comment { id body postId postTitle boardName }
+      comment { id body bodyHTML postId postTitle boardName }
       message { id body }
     }
   }

--- a/frontend/pages/@[username]/comments.vue
+++ b/frontend/pages/@[username]/comments.vue
@@ -2,6 +2,7 @@
 import { useGraphQL } from '~/composables/useGraphQL'
 import type { Comment } from '~/types/generated'
 import { timeAgo } from '~/utils/date'
+import { sanitizeHtml } from '~/utils/sanitize'
 
 const route = useRoute()
 const username = computed(() => route.params.username as string)
@@ -11,6 +12,7 @@ const USER_COMMENTS_QUERY = `
     comments(userName: $userName, sort: $sort, page: $page, limit: $limit) {
       id
       body
+      bodyHTML
       createdAt
       updatedAt
       score
@@ -137,7 +139,8 @@ await fetchComments()
               </span>
             </template>
           </div>
-          <p class="text-sm text-gray-800 leading-relaxed">{{ comment.body }}</p>
+          <div v-if="comment.bodyHTML" class="text-sm text-gray-800 leading-relaxed prose prose-sm max-w-none [&>*]:m-0 line-clamp-3" v-html="sanitizeHtml(comment.bodyHTML)" />
+          <p v-else class="text-sm text-gray-800 leading-relaxed">{{ comment.body }}</p>
         </div>
       </div>
     </div>

--- a/frontend/pages/search.vue
+++ b/frontend/pages/search.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { useGraphQL } from '~/composables/useGraphQL'
 import type { Post, Comment, User, Board } from '~/types/generated'
+import { sanitizeHtml } from '~/utils/sanitize'
 
 useHead({ title: 'Search' })
 
@@ -11,6 +12,7 @@ const SEARCH_QUERY = `
         id
         title
         body
+        bodyHTML
         url
         createdAt
         slug
@@ -22,6 +24,7 @@ const SEARCH_QUERY = `
       comments {
         id
         body
+        bodyHTML
         createdAt
         score
         postId
@@ -197,7 +200,8 @@ if (query.value) {
               </span>
               <span>&middot; {{ comment.score }} points</span>
             </div>
-            <p class="text-sm text-gray-800 line-clamp-3">{{ comment.body }}</p>
+            <div v-if="comment.bodyHTML" class="text-sm text-gray-800 line-clamp-3 prose prose-sm max-w-none [&>*]:m-0" v-html="sanitizeHtml(comment.bodyHTML)" />
+            <p v-else class="text-sm text-gray-800 line-clamp-3">{{ comment.body }}</p>
           </NuxtLink>
         </div>
       </div>


### PR DESCRIPTION
Switch preview snippets from displaying raw text via {{ body }} to rendering sanitized bodyHTML with v-html across PostCard, search results, user profile comments, and notification items.