### PR TITLE
feat(home): redesign home page with feed/discussions tabs

### DIFF
--- a/frontend/components/sidebar/HomeSidebar.vue
+++ b/frontend/components/sidebar/HomeSidebar.vue
@@ -64,18 +64,6 @@ function formatCount (n: number): string {
 
 <template>
   <div class="space-y-4">
-    <!-- New Post button for logged-in users -->
-    <NuxtLink
-      v-if="authStore.isLoggedIn"
-      to="/submit"
-      class="flex items-center justify-center gap-2 w-full rounded-lg bg-primary text-white py-2.5 text-sm font-medium hover:opacity-90 transition-opacity no-underline"
-    >
-      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
-      </svg>
-      New Post
-    </NuxtLink>
-
     <!-- Site welcome card -->
     <div class="bg-white rounded-lg border border-gray-200 overflow-hidden">
       <div class="h-16 bg-gradient-to-br from-primary to-primary-hover" />

--- a/frontend/pages/home/[[sort]].vue
+++ b/frontend/pages/home/[[sort]].vue
@@ -2,7 +2,8 @@
 import { useAuthStore } from '~/stores/auth'
 import { useSiteStore } from '~/stores/site'
 import { usePosts } from '~/composables/usePosts'
-import type { ListingType } from '~/types/generated'
+import { timeAgo, formatDate } from '~/utils/date'
+import type { ListingType, Post } from '~/types/generated'
 
 const authStore = useAuthStore()
 const siteStore = useSiteStore()
@@ -18,17 +19,82 @@ useSeoMeta({
 })
 const route = useRoute()
 
-const { posts, loading, error, page, sort, hasMore, fetchPosts, nextPage, prevPage, setSort } = usePosts({
+// Determine which tabs to show based on subscribed board modes
+const hasFeedBoards = computed(() =>
+  authStore.subscribedBoards.some(b => !b.mode || b.mode === 'feed'),
+)
+const hasForumBoards = computed(() =>
+  authStore.subscribedBoards.some(b => b.mode === 'forum'),
+)
+const showTabs = computed(() => authStore.isLoggedIn && hasFeedBoards.value && hasForumBoards.value)
+
+// Default tab: feed if subscribed to feed boards, otherwise threads
+const activeTab = ref<'feed' | 'threads'>(
+  hasFeedBoards.value ? 'feed' : (hasForumBoards.value ? 'threads' : 'feed'),
+)
+
+// Feed posts composable
+const feedPosts = usePosts({
   listingType: (authStore.isLoggedIn ? 'subscribed' : 'all') as ListingType,
+  postType: authStore.isLoggedIn && hasForumBoards.value ? 'feed' : undefined,
   basePath: '/home',
+})
+
+// Thread posts composable (only used when logged in with forum boards)
+const threadPosts = authStore.isLoggedIn && hasForumBoards.value
+  ? usePosts({
+      listingType: 'subscribed' as ListingType,
+      postType: 'thread',
+    })
+  : null
+
+// Group threads by board for the threads tab
+interface BoardGroup {
+  boardName: string
+  boardTitle: string
+  boardIcon: string | null
+  threads: Post[]
+}
+
+const threadsByBoard = computed<BoardGroup[]>(() => {
+  if (!threadPosts) return []
+  const map = new Map<string, BoardGroup>()
+  for (const post of threadPosts.posts.value) {
+    const key = post.board?.name ?? 'unknown'
+    if (!map.has(key)) {
+      map.set(key, {
+        boardName: key,
+        boardTitle: post.board?.title ?? key,
+        boardIcon: post.board?.icon ?? null,
+        threads: [],
+      })
+    }
+    map.get(key)!.threads.push(post)
+  }
+  return Array.from(map.values())
 })
 
 // Initialize sort from URL param
 if (route.params.sort && typeof route.params.sort === 'string') {
-  sort.value = route.params.sort
+  feedPosts.sort.value = route.params.sort
 }
 
-await fetchPosts()
+// Fetch initial data
+if (activeTab.value === 'feed' || !authStore.isLoggedIn) {
+  await feedPosts.fetchPosts()
+} else if (threadPosts) {
+  await threadPosts.fetchPosts()
+}
+
+async function switchTab (tab: 'feed' | 'threads'): Promise<void> {
+  activeTab.value = tab
+  if (tab === 'feed' && feedPosts.posts.value.length === 0) {
+    await feedPosts.fetchPosts()
+  } else if (tab === 'threads' && threadPosts && threadPosts.posts.value.length === 0) {
+    threadPosts.sort.value = 'newComments'
+    await threadPosts.fetchPosts()
+  }
+}
 </script>
 
 <template>
@@ -68,27 +134,161 @@ await fetchPosts()
       </div>
     </div>
 
-    <!-- Sort bar -->
-    <div class="pt-4">
-      <div class="bg-white rounded-lg border border-gray-200 px-3 py-2 flex items-center justify-between mb-4">
-        <CommonSortSelector v-model="sort" @update:model-value="setSort" />
-        <CommonViewToggle />
+    <!-- Tab bar (only when user has both feed and forum boards) -->
+    <div v-if="showTabs" class="pt-4">
+      <div class="flex gap-1 bg-white rounded-lg border border-gray-200 p-1">
+        <button
+          class="flex-1 flex items-center justify-center gap-2 px-4 py-2 rounded-md text-sm font-medium transition-colors"
+          :class="activeTab === 'feed'
+            ? 'bg-primary text-white shadow-sm'
+            : 'text-gray-600 hover:text-gray-900 hover:bg-gray-50'"
+          @click="switchTab('feed')"
+        >
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 20H5a2 2 0 01-2-2V6a2 2 0 012-2h10a2 2 0 012 2v1m2 13a2 2 0 01-2-2V7m2 13a2 2 0 002-2V9a2 2 0 00-2-2h-2m-4-3H9M7 16h6M7 8h6v4H7V8z" />
+          </svg>
+          Feed
+        </button>
+        <button
+          class="flex-1 flex items-center justify-center gap-2 px-4 py-2 rounded-md text-sm font-medium transition-colors"
+          :class="activeTab === 'threads'
+            ? 'bg-primary text-white shadow-sm'
+            : 'text-gray-600 hover:text-gray-900 hover:bg-gray-50'"
+          @click="switchTab('threads')"
+        >
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z" />
+          </svg>
+          Discussions
+        </button>
       </div>
     </div>
 
-    <!-- Content area -->
-    <div class="pb-4">
-      <CommonErrorDisplay v-if="error" :message="error.message" @retry="fetchPosts" />
+    <!-- Feed tab content -->
+    <div v-show="activeTab === 'feed' || !authStore.isLoggedIn || (!hasFeedBoards && !hasForumBoards)">
+      <!-- Sort bar -->
+      <div class="pt-4">
+        <div class="bg-white rounded-lg border border-gray-200 px-3 py-2 flex items-center justify-between mb-4">
+          <CommonSortSelector v-model="feedPosts.sort.value" @update:model-value="feedPosts.setSort" />
+          <CommonViewToggle />
+        </div>
+      </div>
 
-      <PostList :posts="posts" :loading="loading" />
+      <!-- Content area -->
+      <div class="pb-4">
+        <CommonErrorDisplay v-if="feedPosts.error.value" :message="feedPosts.error.value.message" @retry="feedPosts.fetchPosts" />
 
-      <CommonPagination
-        v-if="posts.length > 0"
-        :page="page"
-        :has-more="hasMore"
-        @prev="prevPage"
-        @next="nextPage"
-      />
+        <PostList :posts="feedPosts.posts.value" :loading="feedPosts.loading.value" />
+
+        <CommonPagination
+          v-if="feedPosts.posts.value.length > 0"
+          :page="feedPosts.page.value"
+          :has-more="feedPosts.hasMore.value"
+          @prev="feedPosts.prevPage"
+          @next="feedPosts.nextPage"
+        />
+      </div>
+    </div>
+
+    <!-- Threads tab content -->
+    <div v-if="threadPosts" v-show="activeTab === 'threads'">
+      <div class="pt-4 pb-4">
+        <CommonErrorDisplay v-if="threadPosts.error.value" :message="threadPosts.error.value.message" @retry="threadPosts.fetchPosts" />
+
+        <CommonLoadingSpinner v-if="threadPosts.loading.value" />
+
+        <div v-else-if="threadsByBoard.length === 0" class="bg-white border border-gray-200 rounded-lg py-12 text-center">
+          <div class="inline-flex w-12 h-12 rounded-full bg-primary/10 items-center justify-center mb-3">
+            <svg class="w-6 h-6 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z" />
+            </svg>
+          </div>
+          <p class="text-sm font-medium text-gray-600 mb-1">No discussions yet</p>
+          <p class="text-xs text-gray-400">The forum boards you follow haven't had any activity yet.</p>
+        </div>
+
+        <!-- Threads grouped by board -->
+        <div v-else class="space-y-6">
+          <div v-for="group in threadsByBoard" :key="group.boardName">
+            <!-- Board header -->
+            <div class="flex items-center gap-2.5 mb-2">
+              <NuxtLink :to="`/b/${group.boardName}`" class="flex items-center gap-2.5 no-underline group">
+                <CommonAvatar
+                  :src="group.boardIcon ?? undefined"
+                  :name="group.boardName"
+                  size="sm"
+                />
+                <h3 class="text-sm font-semibold text-gray-900 group-hover:text-primary transition-colors">
+                  {{ group.boardTitle }}
+                </h3>
+              </NuxtLink>
+              <NuxtLink
+                :to="`/b/${group.boardName}`"
+                class="text-[10px] text-gray-400 hover:text-primary no-underline ml-auto"
+              >
+                View board
+              </NuxtLink>
+            </div>
+
+            <!-- Thread list for this board -->
+            <div class="forum-thread-list">
+              <div class="forum-header">
+                <div class="forum-header-topic">Topic</div>
+                <div class="forum-header-stats">Replies</div>
+                <div class="forum-header-activity">Last Post</div>
+              </div>
+
+              <NuxtLink
+                v-for="thread in group.threads"
+                :key="thread.id"
+                :to="`/b/${group.boardName}/${thread.id}/${thread.slug || ''}`"
+                class="forum-thread no-underline"
+                :class="{ 'forum-thread-pinned': thread.isFeaturedBoard }"
+              >
+                <div class="forum-thread-avatar">
+                  <CommonAvatar
+                    :src="thread.creator?.avatar ?? undefined"
+                    :name="thread.creator?.displayName || thread.creator?.name || '?'"
+                    size="lg"
+                  />
+                </div>
+                <div class="forum-thread-content">
+                  <div class="forum-thread-title-row">
+                    <span v-if="thread.isFeaturedBoard" class="forum-pin-badge">Pinned</span>
+                    <span v-if="thread.isLocked" class="forum-lock-badge" title="Locked">
+                      <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" /></svg>
+                    </span>
+                    <h3 class="forum-thread-title">{{ thread.title }}</h3>
+                  </div>
+                  <p class="forum-thread-meta">
+                    by <span class="forum-thread-author">{{ thread.creator?.displayName || thread.creator?.name || 'unknown' }}</span>
+                    &middot;
+                    <time :datetime="thread.createdAt" :title="thread.createdAt">{{ formatDate(thread.createdAt) }}</time>
+                  </p>
+                </div>
+                <div class="forum-thread-stats">
+                  <span class="forum-stat-number">{{ thread.commentCount }}</span>
+                  <span class="forum-stat-label">{{ thread.commentCount === 1 ? 'reply' : 'replies' }}</span>
+                </div>
+                <div class="forum-thread-last-post">
+                  <template v-if="thread.newestCommentTime && thread.commentCount > 0">
+                    <span class="forum-last-post-time">{{ timeAgo(thread.newestCommentTime) }}</span>
+                  </template>
+                  <span v-else class="forum-last-post-time">&mdash;</span>
+                </div>
+              </NuxtLink>
+            </div>
+          </div>
+        </div>
+
+        <CommonPagination
+          v-if="threadPosts.posts.value.length > 0"
+          :page="threadPosts.page.value"
+          :has-more="threadPosts.hasMore.value"
+          @prev="threadPosts.prevPage"
+          @next="threadPosts.nextPage"
+        />
+      </div>
     </div>
   </div>
 </template>


### PR DESCRIPTION
Split the home feed into two tabs based on subscribed board modes:
- Feed tab shows posts from feed-mode boards with sort/view controls
- Discussions tab shows threads from forum-mode boards grouped by board in the classic forum thread table layout

Tabs only appear when subscribed to both board types. Single-type users see just the relevant view. Anonymous users see all posts as before.

Also removes the "New Post" button from the home sidebar since posts are created from within boards.