### PR TITLE
fix(ui): polish mobile header and bottom nav

### DIFF
--- a/frontend/components/layout/AppHeader.vue
+++ b/frontend/components/layout/AppHeader.vue
@@ -66,10 +66,10 @@ async function handleLogout () {
 
       <!-- Right: Auth actions -->
       <div class="flex items-center gap-1.5 sm:gap-2">
-        <!-- Search (always visible) -->
+        <!-- Search (hidden on mobile — in bottom nav) -->
         <NuxtLink
           to="/search"
-          class="relative flex items-center justify-center w-10 h-10 sm:w-9 sm:h-9 text-white/70 rounded hover:bg-white/10 hover:text-white transition-colors no-underline"
+          class="relative hidden lg:flex items-center justify-center w-9 h-9 text-white/70 rounded hover:bg-white/10 hover:text-white transition-colors no-underline"
           aria-label="Search"
         >
           <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -78,19 +78,21 @@ async function handleLogout () {
         </NuxtLink>
 
         <template v-if="authStore.isLoggedIn">
+          <!-- Submit (hidden on mobile — in bottom nav) -->
           <NuxtLink
             to="/submit"
-            class="relative flex items-center justify-center w-10 h-10 sm:w-9 sm:h-9 text-white rounded hover:bg-white/10 transition-colors no-underline"
+            class="relative hidden lg:flex items-center justify-center w-9 h-9 text-white rounded hover:bg-white/10 transition-colors no-underline"
             aria-label="Submit post"
           >
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
             </svg>
           </NuxtLink>
+          <!-- Admin (hidden on mobile — accessible via sidebar) -->
           <NuxtLink
             v-if="authStore.isAdmin"
             to="/admin"
-            class="relative flex items-center justify-center w-10 h-10 sm:w-9 sm:h-9 text-white/70 rounded hover:bg-white/10 hover:text-white transition-colors no-underline"
+            class="relative hidden lg:flex items-center justify-center w-9 h-9 text-white/70 rounded hover:bg-white/10 hover:text-white transition-colors no-underline"
             aria-label="Admin panel"
           >
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -98,9 +100,10 @@ async function handleLogout () {
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
             </svg>
           </NuxtLink>
+          <!-- Inbox (hidden on mobile — in bottom nav) -->
           <NuxtLink
             to="/inbox"
-            class="relative flex items-center justify-center w-10 h-10 sm:w-9 sm:h-9 text-white/70 rounded hover:bg-white/10 hover:text-white transition-colors no-underline"
+            class="relative hidden lg:flex items-center justify-center w-9 h-9 text-white/70 rounded hover:bg-white/10 hover:text-white transition-colors no-underline"
             aria-label="Inbox"
           >
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -127,7 +130,7 @@ async function handleLogout () {
                 size="sm"
               />
               <span class="hidden sm:inline text-sm font-medium text-white">{{ authStore.user?.name }}</span>
-              <svg class="w-3.5 h-3.5 text-white/60" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg class="w-3.5 h-3.5 text-white/60 hidden sm:block" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
               </svg>
             </button>
@@ -198,13 +201,13 @@ async function handleLogout () {
         <template v-else>
           <NuxtLink
             to="/login"
-            class="button button-sm gray no-underline"
+            class="hidden sm:inline-flex items-center px-3 py-1.5 text-sm font-semibold text-white/90 hover:text-white hover:bg-white/10 rounded-lg transition-colors no-underline"
           >
             Log in
           </NuxtLink>
           <NuxtLink
             to="/register"
-            class="button button-sm primary no-underline"
+            class="inline-flex items-center px-3 py-1.5 text-sm font-semibold text-primary bg-white hover:bg-white/90 rounded-lg transition-colors no-underline"
           >
             Sign up
           </NuxtLink>

--- a/frontend/components/layout/MobileBottomNav.vue
+++ b/frontend/components/layout/MobileBottomNav.vue
@@ -21,7 +21,7 @@ function isActive (path: string): boolean {
         <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
         </svg>
-        <span class="text-[10px] font-medium leading-none">Home</span>
+        <span class="text-[11px] font-medium leading-none">Home</span>
       </NuxtLink>
 
       <NuxtLink
@@ -32,7 +32,7 @@ function isActive (path: string): boolean {
         <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
         </svg>
-        <span class="text-[10px] font-medium leading-none">All</span>
+        <span class="text-[11px] font-medium leading-none">All</span>
       </NuxtLink>
 
       <NuxtLink
@@ -46,7 +46,7 @@ function isActive (path: string): boolean {
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
           </svg>
         </div>
-        <span class="text-[10px] font-medium leading-none">Post</span>
+        <span class="text-[11px] font-medium leading-none">Post</span>
       </NuxtLink>
       <NuxtLink
         v-else
@@ -57,7 +57,7 @@ function isActive (path: string): boolean {
         <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z" />
         </svg>
-        <span class="text-[10px] font-medium leading-none">Boards</span>
+        <span class="text-[11px] font-medium leading-none">Boards</span>
       </NuxtLink>
 
       <NuxtLink
@@ -68,7 +68,7 @@ function isActive (path: string): boolean {
         <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
         </svg>
-        <span class="text-[10px] font-medium leading-none">Search</span>
+        <span class="text-[11px] font-medium leading-none">Search</span>
       </NuxtLink>
 
       <NuxtLink
@@ -88,7 +88,7 @@ function isActive (path: string): boolean {
             {{ authStore.unreadNotificationCount > 99 ? '99+' : authStore.unreadNotificationCount }}
           </span>
         </div>
-        <span class="text-[10px] font-medium leading-none">Inbox</span>
+        <span class="text-[11px] font-medium leading-none">Inbox</span>
       </NuxtLink>
       <NuxtLink
         v-else
@@ -99,7 +99,7 @@ function isActive (path: string): boolean {
         <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
         </svg>
-        <span class="text-[10px] font-medium leading-none">Log in</span>
+        <span class="text-[11px] font-medium leading-none">Log in</span>
       </NuxtLink>
     </div>
     <!-- iOS safe area padding -->


### PR DESCRIPTION
Declutter mobile header by hiding icons already present in the bottom nav (search, submit, inbox, admin). Replace blocky Log in / Sign up buttons with compact header-appropriate links. Bump bottom nav label text from 10px to 11px for better readability. Hide user menu chevron on small screens where the username is already hidden.