### PR TITLE
feat(boards): restructure members page with top contributors and wiki…

### DIFF
--- a/backend/crates/api/src/lib.rs
+++ b/backend/crates/api/src/lib.rs
@@ -34,6 +34,7 @@ use async_graphql::*;
 use queries::{
     banned_users::QueryBannedUsers,
     board_management::QueryBoardManagement,
+    board_members::QueryBoardMembers,
     board_moderators::QueryBoardModerators,
     boards::QueryBoards,
     comments::QueryComments,
@@ -100,6 +101,7 @@ pub struct Query(
     QueryComments,
     QueryBoards,
     QueryBoardManagement,
+    QueryBoardMembers,
     QueryUser,
     QuerySite,
     QueryMessages,

--- a/backend/crates/api/src/queries/board_members.rs
+++ b/backend/crates/api/src/queries/board_members.rs
@@ -1,0 +1,222 @@
+use async_graphql::*;
+use chrono::Utc;
+use diesel::prelude::*;
+use diesel::sql_types::{BigInt, Uuid as DieselUuid};
+use diesel_async::RunQueryDsl;
+use std::collections::HashMap;
+use tinyboards_db::{
+    models::{
+        aggregates::UserAggregates as DbUserAggregates,
+        user::user::User as DbUser,
+    },
+    schema::{users, wiki_page_revisions, wiki_pages},
+    utils::{get_conn, DbPool},
+};
+use tinyboards_utils::TinyBoardsError;
+use uuid::Uuid;
+
+use crate::{helpers::permissions, structs::user::User as GqlUser};
+
+#[derive(Default)]
+pub struct QueryBoardMembers;
+
+/// A user with their contribution score for the board.
+#[derive(SimpleObject)]
+pub struct BoardContributor {
+    pub user: GqlUser,
+    pub post_score: i64,
+    pub comment_score: i64,
+    pub total_score: i64,
+}
+
+/// A user who has edited wiki pages in a board.
+#[derive(SimpleObject)]
+pub struct WikiContributor {
+    pub user: GqlUser,
+    pub edit_count: i64,
+}
+
+#[Object]
+impl QueryBoardMembers {
+    /// Top contributors to a board over the last 30 days, ranked by combined
+    /// post + comment score. Public query.
+    pub async fn get_top_contributors(
+        &self,
+        ctx: &Context<'_>,
+        board_id: ID,
+        limit: Option<i64>,
+    ) -> Result<Vec<BoardContributor>> {
+        let pool = ctx.data::<DbPool>()?;
+        let conn = &mut get_conn(pool).await?;
+
+        let _viewer = permissions::optional_auth(ctx);
+
+        let board_uuid: Uuid = board_id
+            .parse()
+            .map_err(|_| TinyBoardsError::BadRequest("Invalid board ID".to_string()))?;
+
+        let limit = limit.unwrap_or(10).min(25);
+        let cutoff = Utc::now() - chrono::Duration::days(30);
+
+        // Aggregate post scores per creator in this board over the last 30 days.
+        #[derive(QueryableByName)]
+        struct ScoreRow {
+            #[diesel(sql_type = DieselUuid)]
+            creator_id: Uuid,
+            #[diesel(sql_type = BigInt)]
+            total: i64,
+        }
+
+        let post_scores: Vec<ScoreRow> = diesel::sql_query(
+            "SELECT creator_id, COALESCE(SUM(score), 0)::bigint AS total \
+             FROM post_aggregates \
+             WHERE board_id = $1 AND created_at >= $2 \
+             GROUP BY creator_id",
+        )
+        .bind::<DieselUuid, _>(board_uuid)
+        .bind::<diesel::sql_types::Timestamptz, _>(cutoff)
+        .load(conn)
+        .await
+        .map_err(|e| TinyBoardsError::Database(e.to_string()))?;
+
+        let comment_scores: Vec<ScoreRow> = diesel::sql_query(
+            "SELECT c.creator_id, COALESCE(SUM(ca.score), 0)::bigint AS total \
+             FROM comments c \
+             INNER JOIN comment_aggregates ca ON ca.comment_id = c.id \
+             WHERE c.board_id = $1 AND c.created_at >= $2 \
+               AND c.deleted_at IS NULL AND c.is_removed = false \
+             GROUP BY c.creator_id",
+        )
+        .bind::<DieselUuid, _>(board_uuid)
+        .bind::<diesel::sql_types::Timestamptz, _>(cutoff)
+        .load(conn)
+        .await
+        .map_err(|e| TinyBoardsError::Database(e.to_string()))?;
+
+        // Merge into a single map: user_id -> (post_score, comment_score).
+        let mut scores: HashMap<Uuid, (i64, i64)> = HashMap::new();
+        for row in &post_scores {
+            scores.entry(row.creator_id).or_insert((0, 0)).0 = row.total;
+        }
+        for row in &comment_scores {
+            scores.entry(row.creator_id).or_insert((0, 0)).1 = row.total;
+        }
+
+        // Sort by total score descending, take top N.
+        let mut ranked: Vec<(Uuid, i64, i64)> = scores
+            .into_iter()
+            .map(|(uid, (ps, cs))| (uid, ps, cs))
+            .collect();
+        ranked.sort_by(|a, b| (b.1 + b.2).cmp(&(a.1 + a.2)));
+        ranked.truncate(limit as usize);
+
+        if ranked.is_empty() {
+            return Ok(vec![]);
+        }
+
+        // Load user profiles and aggregates.
+        let user_ids: Vec<Uuid> = ranked.iter().map(|(uid, _, _)| *uid).collect();
+
+        let db_users: Vec<DbUser> = users::table
+            .filter(users::id.eq_any(&user_ids))
+            .filter(users::deleted_at.is_null())
+            .load(conn)
+            .await
+            .map_err(|e| TinyBoardsError::Database(e.to_string()))?;
+
+        let aggs: Vec<DbUserAggregates> = tinyboards_db::schema::user_aggregates::table
+            .filter(tinyboards_db::schema::user_aggregates::user_id.eq_any(&user_ids))
+            .load(conn)
+            .await
+            .unwrap_or_default();
+
+        // Build output in ranked order.
+        let contributors = ranked
+            .into_iter()
+            .filter_map(|(uid, ps, cs)| {
+                let user_db = db_users.iter().find(|u| u.id == uid)?;
+                let agg = aggs.iter().find(|a| a.user_id == uid).cloned();
+                Some(BoardContributor {
+                    user: GqlUser::from_db(user_db.clone(), agg),
+                    post_score: ps,
+                    comment_score: cs,
+                    total_score: ps + cs,
+                })
+            })
+            .collect();
+
+        Ok(contributors)
+    }
+
+    /// Users who have contributed to wiki pages in a board, ranked by number
+    /// of edits. Only returns results if the board has wiki enabled. Public query.
+    pub async fn get_wiki_contributors(
+        &self,
+        ctx: &Context<'_>,
+        board_id: ID,
+        limit: Option<i64>,
+    ) -> Result<Vec<WikiContributor>> {
+        let pool = ctx.data::<DbPool>()?;
+        let conn = &mut get_conn(pool).await?;
+
+        let _viewer = permissions::optional_auth(ctx);
+
+        let board_uuid: Uuid = board_id
+            .parse()
+            .map_err(|_| TinyBoardsError::BadRequest("Invalid board ID".to_string()))?;
+
+        let limit = limit.unwrap_or(10).min(25);
+
+        // Count edits per editor across all wiki pages for this board.
+        let edit_counts: Vec<(Uuid, i64)> = wiki_page_revisions::table
+            .inner_join(
+                wiki_pages::table
+                    .on(wiki_pages::id.eq(wiki_page_revisions::page_id)),
+            )
+            .filter(wiki_pages::board_id.eq(board_uuid))
+            .filter(wiki_pages::deleted_at.is_null())
+            .group_by(wiki_page_revisions::editor_id)
+            .select((
+                wiki_page_revisions::editor_id,
+                diesel::dsl::count(wiki_page_revisions::id),
+            ))
+            .order(diesel::dsl::count(wiki_page_revisions::id).desc())
+            .limit(limit)
+            .load(conn)
+            .await
+            .map_err(|e| TinyBoardsError::Database(e.to_string()))?;
+
+        if edit_counts.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let user_ids: Vec<Uuid> = edit_counts.iter().map(|(uid, _)| *uid).collect();
+
+        let db_users: Vec<DbUser> = users::table
+            .filter(users::id.eq_any(&user_ids))
+            .filter(users::deleted_at.is_null())
+            .load(conn)
+            .await
+            .map_err(|e| TinyBoardsError::Database(e.to_string()))?;
+
+        let aggs: Vec<DbUserAggregates> = tinyboards_db::schema::user_aggregates::table
+            .filter(tinyboards_db::schema::user_aggregates::user_id.eq_any(&user_ids))
+            .load(conn)
+            .await
+            .unwrap_or_default();
+
+        let contributors = edit_counts
+            .into_iter()
+            .filter_map(|(uid, count)| {
+                let user_db = db_users.iter().find(|u| u.id == uid)?;
+                let agg = aggs.iter().find(|a| a.user_id == uid).cloned();
+                Some(WikiContributor {
+                    user: GqlUser::from_db(user_db.clone(), agg),
+                    edit_count: count,
+                })
+            })
+            .collect();
+
+        Ok(contributors)
+    }
+}

--- a/backend/crates/api/src/queries/mod.rs
+++ b/backend/crates/api/src/queries/mod.rs
@@ -1,5 +1,6 @@
 pub mod banned_users;
 pub mod board_management;
+pub mod board_members;
 pub mod board_moderators;
 pub mod boards;
 pub mod comments;

--- a/frontend/pages/b/[board]/members.vue
+++ b/frontend/pages/b/[board]/members.vue
@@ -1,10 +1,18 @@
 <script setup lang="ts">
 import { useGraphQL } from '~/composables/useGraphQL'
+import { useBoard } from '~/composables/useBoard'
+import { useAuthStore } from '~/stores/auth'
+import { timeAgo } from '~/utils/date'
 
 const route = useRoute()
 const boardName = route.params.board as string
+const authStore = useAuthStore()
+
+const { board } = useBoard()
 
 useHead({ title: `Members - ${boardName}` })
+
+// ---------- types ----------
 
 interface BoardModerator {
   id: string
@@ -22,47 +30,150 @@ interface BoardModerator {
   isInviteAccepted: boolean
 }
 
-const BOARD_QUERY = `
-  query GetBoard($name: String!) {
-    board(name: $name) { id subscribers }
+interface BoardContributor {
+  user: {
+    id: string
+    name: string
+    displayName: string | null
+    avatar: string | null
   }
-`
+  postScore: number
+  commentScore: number
+  totalScore: number
+}
+
+interface WikiContributor {
+  user: {
+    id: string
+    name: string
+    displayName: string | null
+    avatar: string | null
+  }
+  editCount: number
+}
+
+interface BannedUser {
+  id: string
+  user: {
+    id: string
+    name: string
+    displayName: string | null
+    avatar: string | null
+  }
+  banDate: string
+  expires: string | null
+}
+
+// ---------- queries ----------
 
 const MODERATORS_QUERY = `
   query GetBoardModerators($boardId: ID!) {
     getBoardModerators(boardId: $boardId) {
-      id
-      boardId
-      user {
-        id name displayName avatar isAdmin
-      }
-      createdAt
-      permissions
-      rank
-      isInviteAccepted
+      id boardId
+      user { id name displayName avatar isAdmin }
+      createdAt permissions rank isInviteAccepted
     }
   }
 `
 
+const TOP_CONTRIBUTORS_QUERY = `
+  query GetTopContributors($boardId: ID!, $limit: Int) {
+    getTopContributors(boardId: $boardId, limit: $limit) {
+      user { id name displayName avatar }
+      postScore commentScore totalScore
+    }
+  }
+`
+
+const WIKI_CONTRIBUTORS_QUERY = `
+  query GetWikiContributors($boardId: ID!, $limit: Int) {
+    getWikiContributors(boardId: $boardId, limit: $limit) {
+      user { id name displayName avatar }
+      editCount
+    }
+  }
+`
+
+const BANNED_USERS_QUERY = `
+  query GetBoardBannedUsers($boardId: ID!, $limit: Int) {
+    getBoardBannedUsers(boardId: $boardId, limit: $limit) {
+      id
+      user { id name displayName avatar }
+      banDate expires
+    }
+  }
+`
+
+// ---------- state ----------
+
 const loading = ref(true)
 const moderators = ref<BoardModerator[]>([])
-const subscriberCount = ref(0)
+const topContributors = ref<BoardContributor[]>([])
+const wikiContributors = ref<WikiContributor[]>([])
+const bannedUsers = ref<BannedUser[]>([])
+const isMod = ref(false)
+const bannedExpanded = ref(false)
+
+const wikiEnabled = computed(() => board.value?.wikiEnabled ?? false)
+const subscriberCount = computed(() => board.value?.subscribers ?? 0)
+const boardCreatedAt = computed(() => board.value?.createdAt ?? '')
+
+// ---------- fetch ----------
 
 onMounted(async () => {
-  const { execute: execBoard } = useGraphQL<{ board: { id: string; subscribers: number } }>()
-  const boardResult = await execBoard(BOARD_QUERY, { variables: { name: boardName } })
-  if (!boardResult?.board) {
+  if (!board.value?.id) {
     loading.value = false
     return
   }
 
-  subscriberCount.value = boardResult.board.subscribers
+  const boardId = board.value.id
 
-  const { execute: execMods } = useGraphQL<{ getBoardModerators: BoardModerator[] }>()
-  const modsResult = await execMods(MODERATORS_QUERY, { variables: { boardId: boardResult.board.id } })
-  if (modsResult?.getBoardModerators) {
-    moderators.value = modsResult.getBoardModerators.filter(m => m.isInviteAccepted)
-  }
+  // Fire all public queries in parallel.
+  const modsPromise = (async () => {
+    const { execute } = useGraphQL<{ getBoardModerators: BoardModerator[] }>()
+    const res = await execute(MODERATORS_QUERY, { variables: { boardId } })
+    if (res?.getBoardModerators) {
+      moderators.value = res.getBoardModerators.filter(m => m.isInviteAccepted)
+    }
+  })()
+
+  const contribPromise = (async () => {
+    const { execute } = useGraphQL<{ getTopContributors: BoardContributor[] }>()
+    const res = await execute(TOP_CONTRIBUTORS_QUERY, { variables: { boardId, limit: 10 } })
+    if (res?.getTopContributors) {
+      topContributors.value = res.getTopContributors
+    }
+  })()
+
+  const wikiPromise = wikiEnabled.value
+    ? (async () => {
+        const { execute } = useGraphQL<{ getWikiContributors: WikiContributor[] }>()
+        const res = await execute(WIKI_CONTRIBUTORS_QUERY, { variables: { boardId, limit: 10 } })
+        if (res?.getWikiContributors) {
+          wikiContributors.value = res.getWikiContributors
+        }
+      })()
+    : Promise.resolve()
+
+  // Banned users — only if the user might be a mod (logged in).
+  // The query itself enforces permissions; if the user is not a mod the API
+  // returns an error which we silently swallow.
+  const bannedPromise = authStore.isLoggedIn
+    ? (async () => {
+        try {
+          const { execute } = useGraphQL<{ getBoardBannedUsers: BannedUser[] }>()
+          const res = await execute(BANNED_USERS_QUERY, { variables: { boardId, limit: 25 } })
+          if (res?.getBoardBannedUsers) {
+            bannedUsers.value = res.getBoardBannedUsers
+            isMod.value = true
+          }
+        } catch {
+          // Not a mod — hide the section.
+        }
+      })()
+    : Promise.resolve()
+
+  await Promise.all([modsPromise, contribPromise, wikiPromise, bannedPromise])
   loading.value = false
 })
 
@@ -77,21 +188,33 @@ function formatDate (dateStr: string): string {
 
 <template>
   <div>
-    <div class="bg-white rounded-lg border border-gray-200 px-4 py-3 mb-4">
-      <h2 class="text-base font-semibold text-gray-900">
-        Members
-      </h2>
-      <p class="text-sm text-gray-500 mt-0.5">
-        {{ subscriberCount }} {{ subscriberCount === 1 ? 'subscriber' : 'subscribers' }}
-      </p>
+    <!-- Stat bar -->
+    <div class="flex items-center gap-3 bg-white rounded-lg border border-gray-200 px-4 py-3 mb-5 text-sm text-gray-600">
+      <div class="flex items-center gap-1.5">
+        <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z" />
+        </svg>
+        <span class="font-medium text-gray-900">{{ subscriberCount.toLocaleString() }}</span>
+        {{ subscriberCount === 1 ? 'subscriber' : 'subscribers' }}
+      </div>
+      <span v-if="boardCreatedAt" class="text-gray-300">&middot;</span>
+      <div v-if="boardCreatedAt" class="flex items-center gap-1.5">
+        <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+        </svg>
+        Created {{ timeAgo(boardCreatedAt) }}
+      </div>
     </div>
 
     <CommonLoadingSpinner v-if="loading" />
 
     <template v-else>
-      <div v-if="moderators.length > 0" class="mb-6">
-        <h3 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3 px-1">Moderators</h3>
-        <div class="space-y-2">
+      <!-- ============ Moderators ============ -->
+      <section class="mb-6">
+        <h3 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3 px-1">
+          Moderators
+        </h3>
+        <div v-if="moderators.length > 0" class="space-y-2">
           <div
             v-for="mod in moderators"
             :key="mod.id"
@@ -106,14 +229,118 @@ function formatDate (dateStr: string): string {
                 @{{ mod.user.name }}
                 <span v-if="mod.rank === 0" class="ml-1 text-primary font-medium">Owner</span>
                 <span v-else class="ml-1">Mod</span>
-                &middot; Joined {{ formatDate(mod.createdAt) }}
+                &middot; Since {{ formatDate(mod.createdAt) }}
               </p>
             </div>
           </div>
         </div>
-      </div>
+        <p v-else class="text-sm text-gray-400 px-1">No moderators.</p>
+      </section>
 
-      <div v-if="moderators.length === 0 && subscriberCount === 0" class="text-center py-8">
+      <!-- ============ Top Contributors ============ -->
+      <section v-if="topContributors.length > 0" class="mb-6">
+        <h3 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3 px-1">
+          Top Contributors
+          <span class="font-normal normal-case tracking-normal text-gray-300 ml-1">last 30 days</span>
+        </h3>
+        <div class="bg-white rounded-lg border border-gray-200 divide-y divide-gray-100">
+          <div
+            v-for="(contributor, idx) in topContributors"
+            :key="contributor.user.id"
+            class="flex items-center gap-3 px-3 py-2.5"
+          >
+            <span class="w-5 text-center text-xs font-semibold text-gray-400">#{{ idx + 1 }}</span>
+            <CommonAvatar :src="contributor.user.avatar ?? undefined" :name="contributor.user.name" size="sm" />
+            <div class="flex-1 min-w-0">
+              <NuxtLink :to="`/@${contributor.user.name}`" class="text-sm font-medium text-gray-900 hover:underline">
+                {{ contributor.user.displayName || contributor.user.name }}
+              </NuxtLink>
+            </div>
+            <div class="flex items-center gap-2 text-xs text-gray-500 shrink-0">
+              <span title="Post score">{{ contributor.postScore.toLocaleString() }} post</span>
+              <span class="text-gray-300">&middot;</span>
+              <span title="Comment score">{{ contributor.commentScore.toLocaleString() }} comment</span>
+              <span class="text-gray-300">&middot;</span>
+              <span class="font-medium text-gray-700" title="Total score">{{ contributor.totalScore.toLocaleString() }}</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ Banned Members (mod-only, collapsible) ============ -->
+      <section v-if="isMod" class="mb-6">
+        <button
+          class="flex items-center gap-1.5 text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3 px-1 hover:text-gray-600 transition-colors"
+          @click="bannedExpanded = !bannedExpanded"
+        >
+          <svg
+            class="w-3.5 h-3.5 transition-transform"
+            :class="bannedExpanded ? 'rotate-90' : ''"
+            fill="none" stroke="currentColor" viewBox="0 0 24 24"
+          >
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+          </svg>
+          Banned Members
+          <span v-if="bannedUsers.length > 0" class="font-normal normal-case tracking-normal text-gray-300 ml-0.5">({{ bannedUsers.length }})</span>
+        </button>
+
+        <template v-if="bannedExpanded">
+          <div v-if="bannedUsers.length > 0" class="bg-white rounded-lg border border-gray-200 divide-y divide-gray-100">
+            <div
+              v-for="ban in bannedUsers"
+              :key="ban.id"
+              class="flex items-center gap-3 px-3 py-2.5"
+            >
+              <CommonAvatar :src="ban.user.avatar ?? undefined" :name="ban.user.name" size="sm" />
+              <div class="flex-1 min-w-0">
+                <NuxtLink :to="`/@${ban.user.name}`" class="text-sm font-medium text-gray-900 hover:underline">
+                  {{ ban.user.displayName || ban.user.name }}
+                </NuxtLink>
+                <p class="text-xs text-gray-500">
+                  Banned {{ formatDate(ban.banDate) }}
+                  <template v-if="ban.expires">
+                    &middot; Expires {{ formatDate(ban.expires) }}
+                  </template>
+                  <template v-else>
+                    &middot; Permanent
+                  </template>
+                </p>
+              </div>
+            </div>
+          </div>
+          <p v-else class="text-sm text-gray-400 px-1">No banned members.</p>
+        </template>
+      </section>
+
+      <!-- ============ Wiki Contributors ============ -->
+      <section v-if="wikiEnabled && wikiContributors.length > 0" class="mb-6">
+        <h3 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3 px-1">
+          Wiki Contributors
+        </h3>
+        <div class="bg-white rounded-lg border border-gray-200 divide-y divide-gray-100">
+          <div
+            v-for="contributor in wikiContributors"
+            :key="contributor.user.id"
+            class="flex items-center gap-3 px-3 py-2.5"
+          >
+            <CommonAvatar :src="contributor.user.avatar ?? undefined" :name="contributor.user.name" size="sm" />
+            <div class="flex-1 min-w-0">
+              <NuxtLink :to="`/@${contributor.user.name}`" class="text-sm font-medium text-gray-900 hover:underline">
+                {{ contributor.user.displayName || contributor.user.name }}
+              </NuxtLink>
+            </div>
+            <span class="text-xs text-gray-500 shrink-0">
+              {{ contributor.editCount }} {{ contributor.editCount === 1 ? 'edit' : 'edits' }}
+            </span>
+          </div>
+        </div>
+      </section>
+
+      <!-- Empty state -->
+      <div
+        v-if="moderators.length === 0 && topContributors.length === 0 && subscriberCount === 0"
+        class="text-center py-8"
+      >
         <p class="text-sm text-gray-500">No members yet.</p>
       </div>
     </template>

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -86,8 +86,12 @@ type Query {
     limit: Int
   ): SearchResult!
 
-  # Moderation
+  # Board members
   getBoardModerators(boardId: ID!): [BoardModerator!]!
+  getTopContributors(boardId: ID!, limit: Int): [BoardContributor!]!
+  getWikiContributors(boardId: ID!, limit: Int): [WikiContributor!]!
+
+  # Moderation
   getModeratedBoards(page: Int, limit: Int): [Board!]!
   getBoardSettings(boardId: ID!): BoardSettings!
   getBoardBannedUsers(boardId: ID!, page: Int, limit: Int): [BoardBannedUser!]!
@@ -557,6 +561,18 @@ type BoardModerator {
   permissions: Int!
   rank: Int!
   isInviteAccepted: Boolean!
+}
+
+type BoardContributor {
+  user: User!
+  postScore: Int!
+  commentScore: Int!
+  totalScore: Int!
+}
+
+type WikiContributor {
+  user: User!
+  editCount: Int!
 }
 
 type BoardSettings {

--- a/frontend/types/generated.ts
+++ b/frontend/types/generated.ts
@@ -75,6 +75,7 @@ export type Board = {
   banner?: Maybe<Scalars['String']['output']>;
   comments: Scalars['Int']['output'];
   createdAt: Scalars['String']['output'];
+  customCss?: Maybe<Scalars['String']['output']>;
   description?: Maybe<Scalars['String']['output']>;
   excludeFromAll: Scalars['Boolean']['output'];
   hoverColor: Scalars['String']['output'];
@@ -86,12 +87,12 @@ export type Board = {
   isPostingRestrictedToMods: Scalars['Boolean']['output'];
   isRemoved: Scalars['Boolean']['output'];
   isSubscribed: Scalars['Boolean']['output'];
+  mode: Scalars['String']['output'];
   name: Scalars['String']['output'];
   posts: Scalars['Int']['output'];
   primaryColor: Scalars['String']['output'];
   publicBanReason?: Maybe<Scalars['String']['output']>;
   secondaryColor: Scalars['String']['output'];
-  mode: Scalars['String']['output'];
   sidebar?: Maybe<Scalars['String']['output']>;
   sidebarHTML?: Maybe<Scalars['String']['output']>;
   subscribers: Scalars['Int']['output'];
@@ -102,7 +103,6 @@ export type Board = {
   usersActiveMonth: Scalars['Int']['output'];
   usersActiveWeek: Scalars['Int']['output'];
   wikiEnabled: Scalars['Boolean']['output'];
-  customCss?: Maybe<Scalars['String']['output']>;
 };
 
 export type BoardBanResponse = {
@@ -125,6 +125,14 @@ export type BoardBannedUser = {
   boardId: Scalars['ID']['output'];
   expires?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
+  user: User;
+};
+
+export type BoardContributor = {
+  __typename?: 'BoardContributor';
+  commentScore: Scalars['Int']['output'];
+  postScore: Scalars['Int']['output'];
+  totalScore: Scalars['Int']['output'];
   user: User;
 };
 
@@ -227,11 +235,11 @@ export type CreateBoardInput = {
   hoverColor?: InputMaybe<Scalars['String']['input']>;
   icon?: InputMaybe<Scalars['String']['input']>;
   isNsfw?: InputMaybe<Scalars['Boolean']['input']>;
+  mode?: InputMaybe<Scalars['String']['input']>;
   name: Scalars['String']['input'];
   primaryColor?: InputMaybe<Scalars['String']['input']>;
   secondaryColor?: InputMaybe<Scalars['String']['input']>;
   title: Scalars['String']['input'];
-  mode?: InputMaybe<Scalars['String']['input']>;
   wikiEnabled?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
@@ -452,7 +460,10 @@ export type LocalSite = {
   captchaDifficulty: Scalars['String']['output'];
   captchaEnabled: Scalars['Boolean']['output'];
   createdAt: Scalars['String']['output'];
+  customCss?: Maybe<Scalars['String']['output']>;
+  customCssEnabled: Scalars['Boolean']['output'];
   defaultAvatar?: Maybe<Scalars['String']['output']>;
+  defaultBoardMode: Scalars['String']['output'];
   defaultPostListingType: Scalars['String']['output'];
   defaultTheme: Scalars['String']['output'];
   description?: Maybe<Scalars['String']['output']>;
@@ -473,12 +484,13 @@ export type LocalSite = {
   registrationMode: Scalars['String']['output'];
   requireEmailVerification: Scalars['Boolean']['output'];
   secondaryColor: Scalars['String']['output'];
+  trustedUserManualApproval: Scalars['Boolean']['output'];
+  trustedUserMinAccountAgeDays: Scalars['Int']['output'];
+  trustedUserMinPosts: Scalars['Int']['output'];
+  trustedUserMinReputation: Scalars['Int']['output'];
   updatedAt: Scalars['String']['output'];
   welcomeMessage?: Maybe<Scalars['String']['output']>;
   wordFilterEnabled: Scalars['Boolean']['output'];
-  defaultBoardMode: Scalars['String']['output'];
-  customCss?: Maybe<Scalars['String']['output']>;
-  customCssEnabled: Scalars['Boolean']['output'];
 };
 
 export type MarkNotificationsReadResponse = {
@@ -540,15 +552,19 @@ export type Mutation = {
   createPost: Post;
   createWikiPage: WikiPage;
   deleteAccount: Scalars['Boolean']['output'];
+  deleteComment: Comment;
   deleteEmoji: Scalars['Boolean']['output'];
   deleteFlairCategory: Scalars['Boolean']['output'];
   deleteFlairTemplate: Scalars['Boolean']['output'];
   deleteInvite: Scalars['Boolean']['output'];
   deleteMessage: Scalars['Boolean']['output'];
   deleteNotification: DeleteNotificationResponse;
+  deletePost: Post;
   deleteWikiPage: Scalars['Boolean']['output'];
   denyApplication: Scalars['Boolean']['output'];
   dismissReport: ResolveReportResponse;
+  distinguishComment: Comment;
+  distinguishPost: Post;
   editComment: Comment;
   editMessage: EditMessageResponse;
   editPost: Post;
@@ -576,6 +592,7 @@ export type Mutation = {
   saveComment: Comment;
   savePost: Post;
   sendMessage: SendMessageResponse;
+  setUserAdminLevel: User;
   subscribeToBoard: Scalars['Boolean']['output'];
   transferBoardOwnership: TransferOwnershipResponse;
   unbanUserFromBoard: BoardUnbanResponse;
@@ -727,6 +744,16 @@ export type MutationCreateWikiPageArgs = {
 };
 
 
+export type MutationDeleteAccountArgs = {
+  userId: Scalars['ID']['input'];
+};
+
+
+export type MutationDeleteCommentArgs = {
+  commentId: Scalars['ID']['input'];
+};
+
+
 export type MutationDeleteEmojiArgs = {
   emojiId: Scalars['ID']['input'];
 };
@@ -757,6 +784,11 @@ export type MutationDeleteNotificationArgs = {
 };
 
 
+export type MutationDeletePostArgs = {
+  postId: Scalars['ID']['input'];
+};
+
+
 export type MutationDeleteWikiPageArgs = {
   pageId: Scalars['ID']['input'];
 };
@@ -771,6 +803,16 @@ export type MutationDenyApplicationArgs = {
 export type MutationDismissReportArgs = {
   reportId: Scalars['ID']['input'];
   reportType: Scalars['String']['input'];
+};
+
+
+export type MutationDistinguishCommentArgs = {
+  commentId: Scalars['ID']['input'];
+};
+
+
+export type MutationDistinguishPostArgs = {
+  postId: Scalars['ID']['input'];
 };
 
 
@@ -916,6 +958,12 @@ export type MutationSavePostArgs = {
 
 export type MutationSendMessageArgs = {
   input: SendMessageInput;
+};
+
+
+export type MutationSetUserAdminLevelArgs = {
+  adminLevel: Scalars['Int']['input'];
+  userId: Scalars['ID']['input'];
 };
 
 
@@ -1122,10 +1170,10 @@ export type Post = {
   bodyHTML: Scalars['String']['output'];
   commentCount: Scalars['Int']['output'];
   controversyRank: Scalars['Float']['output'];
-  distinguishedAs?: Maybe<Scalars['String']['output']>;
   createdAt: Scalars['String']['output'];
   creator?: Maybe<User>;
   creatorId: Scalars['ID']['output'];
+  distinguishedAs?: Maybe<Scalars['String']['output']>;
   downvotes: Scalars['Int']['output'];
   embedDescription?: Maybe<Scalars['String']['output']>;
   embedTitle?: Maybe<Scalars['String']['output']>;
@@ -1221,9 +1269,11 @@ export type Query = {
   getNotificationSettings: NotificationSettings;
   getNotifications: Array<Notification>;
   getPostReports: Array<PostReportView>;
+  getTopContributors: Array<BoardContributor>;
   getUnreadMessageCount: Scalars['Int']['output'];
   getUnreadNotificationCount: UnreadNotificationCount;
   getUserSettings: UserSettings;
+  getWikiContributors: Array<WikiContributor>;
   isFollowingUser: Scalars['Boolean']['output'];
   listBannedUsers: BannedUsersResponse;
   listBoards: Array<Board>;
@@ -1350,6 +1400,18 @@ export type QueryGetPostReportsArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   statusFilter?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryGetTopContributorsArgs = {
+  boardId: Scalars['ID']['input'];
+  limit?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type QueryGetWikiContributorsArgs = {
+  boardId: Scalars['ID']['input'];
+  limit?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -1619,6 +1681,7 @@ export type UpdateBoardReactionSettingsResponse = {
 export type UpdateBoardSettingsInput = {
   banner?: InputMaybe<Scalars['String']['input']>;
   boardId: Scalars['ID']['input'];
+  customCss?: InputMaybe<Scalars['String']['input']>;
   description?: InputMaybe<Scalars['String']['input']>;
   excludeFromAll?: InputMaybe<Scalars['Boolean']['input']>;
   hoverColor?: InputMaybe<Scalars['String']['input']>;
@@ -1632,7 +1695,6 @@ export type UpdateBoardSettingsInput = {
   sidebar?: InputMaybe<Scalars['String']['input']>;
   title?: InputMaybe<Scalars['String']['input']>;
   wikiEnabled?: InputMaybe<Scalars['Boolean']['input']>;
-  customCss?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type UpdateBoardSettingsResponse = {
@@ -1724,6 +1786,9 @@ export type UpdateSiteConfigInput = {
   boardsEnabled?: InputMaybe<Scalars['Boolean']['input']>;
   captchaDifficulty?: InputMaybe<Scalars['String']['input']>;
   captchaEnabled?: InputMaybe<Scalars['Boolean']['input']>;
+  customCss?: InputMaybe<Scalars['String']['input']>;
+  customCssEnabled?: InputMaybe<Scalars['Boolean']['input']>;
+  defaultBoardMode?: InputMaybe<Scalars['String']['input']>;
   defaultTheme?: InputMaybe<Scalars['String']['input']>;
   description?: InputMaybe<Scalars['String']['input']>;
   emojiEnabled?: InputMaybe<Scalars['Boolean']['input']>;
@@ -1744,11 +1809,12 @@ export type UpdateSiteConfigInput = {
   reportsEmailAdmins?: InputMaybe<Scalars['Boolean']['input']>;
   requireEmailVerification?: InputMaybe<Scalars['Boolean']['input']>;
   secondaryColor?: InputMaybe<Scalars['String']['input']>;
+  trustedUserManualApproval?: InputMaybe<Scalars['Boolean']['input']>;
+  trustedUserMinAccountAgeDays?: InputMaybe<Scalars['Int']['input']>;
+  trustedUserMinPosts?: InputMaybe<Scalars['Int']['input']>;
+  trustedUserMinReputation?: InputMaybe<Scalars['Int']['input']>;
   welcomeMessage?: InputMaybe<Scalars['String']['input']>;
   wordFilterEnabled?: InputMaybe<Scalars['Boolean']['input']>;
-  defaultBoardMode?: InputMaybe<Scalars['String']['input']>;
-  customCss?: InputMaybe<Scalars['String']['input']>;
-  customCssEnabled?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type User = {
@@ -1808,6 +1874,12 @@ export type UserSettings = {
   showNSFW: Scalars['Boolean']['output'];
   theme: Scalars['String']['output'];
   updatedAt: Scalars['String']['output'];
+};
+
+export type WikiContributor = {
+  __typename?: 'WikiContributor';
+  editCount: Scalars['Int']['output'];
+  user: User;
 };
 
 export type WikiPage = {

--- a/schema.graphql
+++ b/schema.graphql
@@ -86,8 +86,12 @@ type Query {
     limit: Int
   ): SearchResult!
 
-  # Moderation
+  # Board members
   getBoardModerators(boardId: ID!): [BoardModerator!]!
+  getTopContributors(boardId: ID!, limit: Int): [BoardContributor!]!
+  getWikiContributors(boardId: ID!, limit: Int): [WikiContributor!]!
+
+  # Moderation
   getModeratedBoards(page: Int, limit: Int): [Board!]!
   getBoardSettings(boardId: ID!): BoardSettings!
   getBoardBannedUsers(boardId: ID!, page: Int, limit: Int): [BoardBannedUser!]!
@@ -601,6 +605,18 @@ type BoardModerator {
   permissions: Int!
   rank: Int!
   isInviteAccepted: Boolean!
+}
+
+type BoardContributor {
+  user: User!
+  postScore: Int!
+  commentScore: Int!
+  totalScore: Int!
+}
+
+type WikiContributor {
+  user: User!
+  editCount: Int!
 }
 
 type BoardSettings {


### PR DESCRIPTION
… editors

Add new sections to the board members tab:
- Stat bar showing subscriber count and board age
- Moderators (existing, always shown)
- Top Contributors ranked by post + comment score over the last 30 days
- Banned Members (mod-only, collapsible)
- Wiki Contributors (only shown when wiki is enabled)

Backend: add getTopContributors and getWikiContributors GraphQL queries with aggregation across post_aggregates and comment_aggregates/wiki_page_revisions.