### PR TITLE
feat(forum): add participant avatars, new badge, and sidebar activity…

### DIFF
--- a/frontend/assets/css/main.css
+++ b/frontend/assets/css/main.css
@@ -850,6 +850,68 @@ a:focus:not(:focus-visible) {
   color: #64748b;
 }
 
+/* New activity badge */
+.forum-new-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 6px;
+  border-radius: 3px;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #15803d;
+  background: #dcfce7;
+  flex-shrink: 0;
+}
+
+.dark .forum-new-badge {
+  background: rgba(34, 197, 94, 0.15);
+  color: #4ade80;
+}
+
+/* Meta row: wraps meta text + participant avatars */
+.forum-thread-meta-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+/* Participant avatar stack */
+.forum-thread-participants {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.forum-participants-overflow {
+  margin-left: 4px;
+  font-size: 11px;
+  font-weight: 600;
+  color: #94a3b8;
+}
+
+.dark .forum-participants-overflow {
+  color: #64748b;
+}
+
+/* Last post author name */
+.forum-last-post-author {
+  display: block;
+  font-size: 12px;
+  font-weight: 500;
+  color: #475569;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1.3;
+}
+
+.dark .forum-last-post-author {
+  color: #cbd5e1;
+}
+
 /* Smooth scroll behavior */
 html {
   scroll-behavior: smooth;

--- a/frontend/components/sidebar/BoardPageSidebar.vue
+++ b/frontend/components/sidebar/BoardPageSidebar.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import { useBoard } from '~/composables/useBoard'
+import { useBoardActivity } from '~/composables/useBoardActivity'
 import { useAuthStore } from '~/stores/auth'
 import { useGraphQL } from '~/composables/useGraphQL'
-import { formatDate } from '~/utils/date'
+import { formatDate, timeAgo } from '~/utils/date'
 import { sanitizeHtml } from '~/utils/sanitize'
 
 const route = useRoute()
@@ -52,6 +53,18 @@ const createButtonLink = computed(() => {
   if (board.value.mode === 'forum') return `/b/${board.value.name}/submit?type=thread`
   return `/b/${board.value.name}/submit`
 })
+
+// Latest activity for forum boards
+const isForumBoard = computed(() => board.value?.mode === 'forum')
+const activityComposable = boardName.value ? useBoardActivity(boardName.value) : null
+const latestActivity = computed(() => activityComposable?.latestActivity.value ?? [])
+const activityLoading = computed(() => activityComposable?.loading.value ?? false)
+
+watch(isForumBoard, async (isForum) => {
+  if (isForum && activityComposable) {
+    await activityComposable.fetchActivity()
+  }
+}, { immediate: true })
 </script>
 
 <template>
@@ -154,6 +167,48 @@ const createButtonLink = computed(() => {
             <div class="text-sm font-medium text-gray-900">{{ formatDate(board.createdAt) }}</div>
             <div class="text-[11px] text-gray-500">Created</div>
           </div>
+        </div>
+      </div>
+
+      <!-- Latest Activity (forum boards only) -->
+      <div v-if="isForumBoard" class="bg-white rounded-lg border border-gray-200 overflow-hidden">
+        <div class="px-4 py-2 border-b border-gray-200 flex items-center gap-2">
+          <svg class="w-4 h-4 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+          </svg>
+          <h3 class="font-semibold text-sm text-gray-900">Latest Activity</h3>
+        </div>
+        <div v-if="activityLoading" class="p-3 space-y-3">
+          <div v-for="n in 3" :key="n" class="flex items-center gap-2.5">
+            <div class="w-5 h-5 rounded-full bg-gray-200 animate-pulse shrink-0" />
+            <div class="flex-1 space-y-1">
+              <div class="h-3 bg-gray-200 rounded animate-pulse w-3/4" />
+              <div class="h-2.5 bg-gray-100 rounded animate-pulse w-1/3" />
+            </div>
+          </div>
+        </div>
+        <div v-else-if="latestActivity.length === 0" class="p-4 text-center">
+          <p class="text-xs text-gray-400">No recent activity</p>
+        </div>
+        <div v-else class="divide-y divide-gray-100">
+          <NuxtLink
+            v-for="entry in latestActivity"
+            :key="entry.postId"
+            :to="`/b/${board.name}/${entry.postId}/${entry.postSlug || ''}`"
+            class="flex items-center gap-2.5 px-4 py-2.5 hover:bg-gray-50 transition-colors no-underline"
+          >
+            <CommonAvatar
+              :src="entry.commenterAvatar ?? undefined"
+              :name="entry.commenterName"
+              size="xs"
+            />
+            <div class="flex-1 min-w-0">
+              <p class="text-sm text-gray-800 font-medium truncate leading-tight">{{ entry.postTitle }}</p>
+              <p class="text-[11px] text-gray-400 leading-tight mt-0.5">
+                {{ entry.commenterName }} &middot; {{ timeAgo(entry.createdAt) }}
+              </p>
+            </div>
+          </NuxtLink>
         </div>
       </div>
     </template>

--- a/frontend/composables/useBoardActivity.ts
+++ b/frontend/composables/useBoardActivity.ts
@@ -1,0 +1,152 @@
+import { ref } from 'vue'
+import type { Ref } from 'vue'
+import { useGraphQL } from '~/composables/useGraphQL'
+import type { ApiError } from '~/types/api'
+
+export interface ParticipantUser {
+  id: string
+  name: string
+  displayName: string | null
+  avatar: string | null
+}
+
+export interface ActivityEntry {
+  postId: string
+  postTitle: string
+  postSlug: string
+  commenterName: string
+  commenterAvatar: string | null
+  createdAt: string
+}
+
+interface CommentResult {
+  id: string
+  postId: string
+  createdAt: string
+  creator: {
+    id: string
+    name: string
+    displayName: string | null
+    avatar: string | null
+  } | null
+  post: {
+    id: string
+    title: string
+    slug: string
+  }
+}
+
+interface CommentsResponse {
+  comments: CommentResult[]
+}
+
+const BOARD_COMMENTS_QUERY = `
+  query BoardRecentComments($boardName: String!, $sort: CommentSortType, $limit: Int) {
+    comments(boardName: $boardName, sort: $sort, limit: $limit) {
+      id
+      postId
+      createdAt
+      creator {
+        id
+        name
+        displayName
+        avatar
+      }
+      post {
+        id
+        title
+        slug
+      }
+    }
+  }
+`
+
+interface UseBoardActivityReturn {
+  threadParticipants: Ref<Map<string, ParticipantUser[]>>
+  threadLastReply: Ref<Map<string, { creatorName: string; createdAt: string }>>
+  latestActivity: Ref<ActivityEntry[]>
+  loading: Ref<boolean>
+  error: Ref<ApiError | null>
+  fetchActivity: () => Promise<void>
+}
+
+export function useBoardActivity (boardName: string): UseBoardActivityReturn {
+  const { execute, loading, error } = useGraphQL<CommentsResponse>()
+
+  const threadParticipants = ref<Map<string, ParticipantUser[]>>(new Map())
+  const threadLastReply = ref<Map<string, { creatorName: string; createdAt: string }>>(new Map())
+  const latestActivity = ref<ActivityEntry[]>([])
+
+  async function fetchActivity (): Promise<void> {
+    const result = await execute(BOARD_COMMENTS_QUERY, {
+      variables: {
+        boardName,
+        sort: 'new',
+        limit: 50,
+      },
+    })
+
+    if (!result?.comments) return
+
+    const comments = result.comments
+    const participantsMap = new Map<string, ParticipantUser[]>()
+    const lastReplyMap = new Map<string, { creatorName: string; createdAt: string }>()
+    const activityList: ActivityEntry[] = []
+    const seenPosts = new Set<string>()
+
+    for (const comment of comments) {
+      if (!comment.creator) continue
+
+      const postId = comment.postId
+
+      // Build last reply map (first occurrence per post = most recent since sorted by new)
+      if (!lastReplyMap.has(postId)) {
+        lastReplyMap.set(postId, {
+          creatorName: comment.creator.displayName || comment.creator.name,
+          createdAt: comment.createdAt,
+        })
+      }
+
+      // Build latest activity list (deduplicated by post, max 5)
+      if (!seenPosts.has(postId) && activityList.length < 5) {
+        seenPosts.add(postId)
+        activityList.push({
+          postId,
+          postTitle: comment.post.title,
+          postSlug: comment.post.slug,
+          commenterName: comment.creator.displayName || comment.creator.name,
+          commenterAvatar: comment.creator.avatar,
+          createdAt: comment.createdAt,
+        })
+      }
+
+      // Build participants map (distinct by creator per post, max 5 per post)
+      if (!participantsMap.has(postId)) {
+        participantsMap.set(postId, [])
+      }
+      const participants = participantsMap.get(postId)!
+      const alreadyAdded = participants.some(p => p.id === comment.creator!.id)
+      if (!alreadyAdded && participants.length < 5) {
+        participants.push({
+          id: comment.creator.id,
+          name: comment.creator.name,
+          displayName: comment.creator.displayName,
+          avatar: comment.creator.avatar,
+        })
+      }
+    }
+
+    threadParticipants.value = participantsMap
+    threadLastReply.value = lastReplyMap
+    latestActivity.value = activityList
+  }
+
+  return {
+    threadParticipants,
+    threadLastReply,
+    latestActivity,
+    loading,
+    error,
+    fetchActivity,
+  }
+}

--- a/frontend/pages/b/[board]/index.vue
+++ b/frontend/pages/b/[board]/index.vue
@@ -1,10 +1,13 @@
 <script setup lang="ts">
 import { usePosts } from '~/composables/usePosts'
 import { useBoard } from '~/composables/useBoard'
+import { useBoardActivity } from '~/composables/useBoardActivity'
+import { useAuthStore } from '~/stores/auth'
 import { timeAgo, formatDate } from '~/utils/date'
 
 const route = useRoute()
 const boardName = route.params.board as string
+const authStore = useAuthStore()
 
 const { board } = useBoard()
 
@@ -28,7 +31,67 @@ if (boardMode.value === 'forum') {
 const pinnedThreads = computed(() => posts.value.filter(p => p.isFeaturedBoard))
 const unpinnedThreads = computed(() => posts.value.filter(p => !p.isFeaturedBoard))
 
+// Activity data for forum boards (participant avatars, last reply info)
+const { threadParticipants, threadLastReply, fetchActivity } = useBoardActivity(boardName)
+
 await fetchPosts()
+if (boardMode.value === 'forum') {
+  await fetchActivity()
+}
+
+// --- Thread visit tracking (localStorage) for "New" badge ---
+const VISITS_KEY = 'tb_thread_visits'
+
+function getVisits (): Record<string, string> {
+  if (!import.meta.client) return {}
+  try {
+    return JSON.parse(localStorage.getItem(VISITS_KEY) || '{}')
+  } catch {
+    return {}
+  }
+}
+
+function pruneOldVisits (visits: Record<string, string>): Record<string, string> {
+  const thirtyDaysAgo = Date.now() - 30 * 24 * 60 * 60 * 1000
+  const pruned: Record<string, string> = {}
+  for (const [id, ts] of Object.entries(visits)) {
+    if (new Date(ts).getTime() > thirtyDaysAgo) {
+      pruned[id] = ts
+    }
+  }
+  return pruned
+}
+
+const threadVisits = ref<Record<string, string>>({})
+
+onMounted(() => {
+  const raw = getVisits()
+  threadVisits.value = pruneOldVisits(raw)
+  if (import.meta.client) {
+    localStorage.setItem(VISITS_KEY, JSON.stringify(threadVisits.value))
+  }
+})
+
+function isThreadNew (thread: { id: string; newestCommentTime: string; commentCount: number }): boolean {
+  if (!authStore.isLoggedIn || thread.commentCount === 0) return false
+  const lastVisit = threadVisits.value[thread.id]
+  if (!lastVisit) return true
+  return thread.newestCommentTime > lastVisit
+}
+
+function markThreadVisited (thread: { id: string; newestCommentTime: string }): void {
+  if (!import.meta.client || !authStore.isLoggedIn) return
+  threadVisits.value[thread.id] = thread.newestCommentTime
+  localStorage.setItem(VISITS_KEY, JSON.stringify(threadVisits.value))
+}
+
+function getParticipants (threadId: string) {
+  return threadParticipants.value.get(threadId) || []
+}
+
+function getLastReply (threadId: string) {
+  return threadLastReply.value.get(threadId)
+}
 </script>
 
 <template>
@@ -71,6 +134,7 @@ await fetchPosts()
             :key="thread.id"
             :to="`/b/${boardName}/${thread.id}/${thread.slug || ''}`"
             class="forum-thread forum-thread-pinned no-underline"
+            @click="markThreadVisited(thread)"
           >
             <div class="forum-thread-avatar">
               <CommonAvatar
@@ -82,23 +146,44 @@ await fetchPosts()
             <div class="forum-thread-content">
               <div class="forum-thread-title-row">
                 <span class="forum-pin-badge">Pinned</span>
+                <span v-if="isThreadNew(thread)" class="forum-new-badge">New</span>
                 <span v-if="thread.isLocked" class="forum-lock-badge" title="Locked">
                   <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" /></svg>
                 </span>
                 <h3 class="forum-thread-title">{{ thread.title }}</h3>
               </div>
-              <p class="forum-thread-meta">
-                by <span class="forum-thread-author">{{ thread.creator?.displayName || thread.creator?.name || 'unknown' }}</span>
-                &middot;
-                <time :datetime="thread.createdAt" :title="thread.createdAt">{{ formatDate(thread.createdAt) }}</time>
-              </p>
+              <div class="forum-thread-meta-row">
+                <p class="forum-thread-meta">
+                  by <span class="forum-thread-author">{{ thread.creator?.displayName || thread.creator?.name || 'unknown' }}</span>
+                  &middot;
+                  <time :datetime="thread.createdAt" :title="thread.createdAt">{{ formatDate(thread.createdAt) }}</time>
+                </p>
+                <div v-if="getParticipants(thread.id).length > 0" class="forum-thread-participants">
+                  <CommonAvatar
+                    v-for="(p, i) in getParticipants(thread.id).slice(0, 4)"
+                    :key="p.id"
+                    :src="p.avatar ?? undefined"
+                    :name="p.displayName || p.name"
+                    size="xs"
+                    :class="{ '-ml-1.5': i > 0 }"
+                    class="ring-2 ring-white"
+                  />
+                  <span v-if="getParticipants(thread.id).length > 4" class="forum-participants-overflow">
+                    +{{ getParticipants(thread.id).length - 4 }}
+                  </span>
+                </div>
+              </div>
             </div>
             <div class="forum-thread-stats">
               <span class="forum-stat-number">{{ thread.commentCount }}</span>
               <span class="forum-stat-label">{{ thread.commentCount === 1 ? 'reply' : 'replies' }}</span>
             </div>
             <div class="forum-thread-last-post">
-              <template v-if="thread.newestCommentTime && thread.commentCount > 0">
+              <template v-if="getLastReply(thread.id)">
+                <span class="forum-last-post-author">{{ getLastReply(thread.id)!.creatorName }}</span>
+                <span class="forum-last-post-time">{{ timeAgo(getLastReply(thread.id)!.createdAt) }}</span>
+              </template>
+              <template v-else-if="thread.newestCommentTime && thread.commentCount > 0">
                 <span class="forum-last-post-time">{{ timeAgo(thread.newestCommentTime) }}</span>
               </template>
               <span v-else class="forum-last-post-time">&mdash;</span>
@@ -112,6 +197,7 @@ await fetchPosts()
           :key="thread.id"
           :to="`/b/${boardName}/${thread.id}/${thread.slug || ''}`"
           class="forum-thread no-underline"
+          @click="markThreadVisited(thread)"
         >
           <div class="forum-thread-avatar">
             <CommonAvatar
@@ -122,23 +208,44 @@ await fetchPosts()
           </div>
           <div class="forum-thread-content">
             <div class="forum-thread-title-row">
+              <span v-if="isThreadNew(thread)" class="forum-new-badge">New</span>
               <span v-if="thread.isLocked" class="forum-lock-badge" title="Locked">
                 <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" /></svg>
               </span>
               <h3 class="forum-thread-title">{{ thread.title }}</h3>
             </div>
-            <p class="forum-thread-meta">
-              by <span class="forum-thread-author">{{ thread.creator?.displayName || thread.creator?.name || 'unknown' }}</span>
-              &middot;
-              <time :datetime="thread.createdAt" :title="thread.createdAt">{{ formatDate(thread.createdAt) }}</time>
-            </p>
+            <div class="forum-thread-meta-row">
+              <p class="forum-thread-meta">
+                by <span class="forum-thread-author">{{ thread.creator?.displayName || thread.creator?.name || 'unknown' }}</span>
+                &middot;
+                <time :datetime="thread.createdAt" :title="thread.createdAt">{{ formatDate(thread.createdAt) }}</time>
+              </p>
+              <div v-if="getParticipants(thread.id).length > 0" class="forum-thread-participants">
+                <CommonAvatar
+                  v-for="(p, i) in getParticipants(thread.id).slice(0, 4)"
+                  :key="p.id"
+                  :src="p.avatar ?? undefined"
+                  :name="p.displayName || p.name"
+                  size="xs"
+                  :class="{ '-ml-1.5': i > 0 }"
+                  class="ring-2 ring-white"
+                />
+                <span v-if="getParticipants(thread.id).length > 4" class="forum-participants-overflow">
+                  +{{ getParticipants(thread.id).length - 4 }}
+                </span>
+              </div>
+            </div>
           </div>
           <div class="forum-thread-stats">
             <span class="forum-stat-number">{{ thread.commentCount }}</span>
             <span class="forum-stat-label">{{ thread.commentCount === 1 ? 'reply' : 'replies' }}</span>
           </div>
           <div class="forum-thread-last-post">
-            <template v-if="thread.newestCommentTime && thread.commentCount > 0">
+            <template v-if="getLastReply(thread.id)">
+              <span class="forum-last-post-author">{{ getLastReply(thread.id)!.creatorName }}</span>
+              <span class="forum-last-post-time">{{ timeAgo(getLastReply(thread.id)!.createdAt) }}</span>
+            </template>
+            <template v-else-if="thread.newestCommentTime && thread.commentCount > 0">
               <span class="forum-last-post-time">{{ timeAgo(thread.newestCommentTime) }}</span>
             </template>
             <span v-else class="forum-last-post-time">&mdash;</span>


### PR DESCRIPTION
… widget

Thread cards in forum-mode boards now show:
- Overlapping avatar stack (max 4, +N overflow) of recent participants
- Last reply author name alongside the relative timestamp
- Green "New" badge for threads with activity since the user's last visit

Board sidebar for forum boards gains a "Latest Activity" widget showing the 5 most recently active threads with commenter avatar, truncated title, and relative timestamp.

New badge tracking uses localStorage (tb_thread_visits) with 30-day auto- pruning. All data comes from the existing comments query — no backend or database changes needed.