### PR TITLE
feat(emojis): add customizable board reaction emojis 

### DIFF
--- a/backend/crates/api/src/mutations/reactions.rs
+++ b/backend/crates/api/src/mutations/reactions.rs
@@ -52,6 +52,10 @@ pub struct UpdateBoardReactionSettingsInput {
     pub board_id: ID,
     pub emoji_weights: Option<Json<serde_json::Value>>,
     pub is_reactions_enabled: Option<bool>,
+    /// JSON array of reaction emoji entries. Each entry:
+    /// `{"type":"unicode","value":"👍"}` or `{"type":"custom","shortcode":"party_parrot","imageUrl":"https://..."}`
+    /// Empty array means "use site defaults".
+    pub reaction_emojis: Option<Json<serde_json::Value>>,
 }
 
 #[derive(SimpleObject)]
@@ -317,6 +321,65 @@ impl ReactionMutations {
             }
         }
 
+        // Validate reaction_emojis if provided
+        if let Some(ref emojis) = input.reaction_emojis {
+            let arr = emojis.0.as_array().ok_or_else(|| {
+                TinyBoardsError::from_message(400, "reaction_emojis must be a JSON array")
+            })?;
+            if arr.len() > 10 {
+                return Err(TinyBoardsError::from_message(
+                    400,
+                    "reaction_emojis can have at most 10 entries",
+                )
+                .into());
+            }
+            for entry in arr {
+                let obj = entry.as_object().ok_or_else(|| {
+                    TinyBoardsError::from_message(400, "Each reaction emoji must be a JSON object")
+                })?;
+                let emoji_type = obj
+                    .get("type")
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| {
+                        TinyBoardsError::from_message(400, "Each reaction emoji must have a 'type' field (\"unicode\" or \"custom\")")
+                    })?;
+                match emoji_type {
+                    "unicode" => {
+                        if obj.get("value").and_then(|v| v.as_str()).is_none() {
+                            return Err(TinyBoardsError::from_message(
+                                400,
+                                "Unicode reaction emoji must have a 'value' field",
+                            )
+                            .into());
+                        }
+                    }
+                    "custom" => {
+                        if obj.get("shortcode").and_then(|v| v.as_str()).is_none() {
+                            return Err(TinyBoardsError::from_message(
+                                400,
+                                "Custom reaction emoji must have a 'shortcode' field",
+                            )
+                            .into());
+                        }
+                        if obj.get("imageUrl").and_then(|v| v.as_str()).is_none() {
+                            return Err(TinyBoardsError::from_message(
+                                400,
+                                "Custom reaction emoji must have an 'imageUrl' field",
+                            )
+                            .into());
+                        }
+                    }
+                    _ => {
+                        return Err(TinyBoardsError::from_message(
+                            400,
+                            "Reaction emoji type must be \"unicode\" or \"custom\"",
+                        )
+                        .into());
+                    }
+                }
+            }
+        }
+
         // Check if settings already exist
         let existing: Option<DbBoardReactionSettings> = board_reaction_settings::table
             .filter(board_reaction_settings::board_id.eq(board_uuid))
@@ -330,6 +393,7 @@ impl ReactionMutations {
             let update_form = BoardReactionSettingsUpdateForm {
                 emoji_weights: input.emoji_weights.map(|j| j.0),
                 is_reactions_enabled: input.is_reactions_enabled,
+                reaction_emojis: input.reaction_emojis.map(|j| j.0),
             };
 
             diesel::update(
@@ -348,6 +412,10 @@ impl ReactionMutations {
                     .map(|j| j.0)
                     .unwrap_or_else(|| serde_json::json!({})),
                 is_reactions_enabled: input.is_reactions_enabled.unwrap_or(true),
+                reaction_emojis: input
+                    .reaction_emojis
+                    .map(|j| j.0)
+                    .unwrap_or_else(|| serde_json::json!([])),
             };
 
             diesel::insert_into(board_reaction_settings::table)

--- a/backend/crates/api/src/queries/board_management.rs
+++ b/backend/crates/api/src/queries/board_management.rs
@@ -8,10 +8,11 @@ use tinyboards_db::{
             board_mods::{BoardModerator as DbBoardModerator, ModPerms},
             boards::Board as DbBoard,
         },
+        reaction::BoardReactionSettings as DbBoardReactionSettings,
         social::BoardUserBan,
         user::user::{AdminPerms, User as DbUser},
     },
-    schema::{board_aggregates, board_moderators, board_user_bans, boards, user_aggregates, users},
+    schema::{board_aggregates, board_moderators, board_reaction_settings, board_user_bans, boards, user_aggregates, users},
     utils::{get_conn, DbPool},
 };
 use tinyboards_utils::TinyBoardsError;
@@ -19,7 +20,11 @@ use uuid::Uuid;
 
 use crate::{
     helpers::permissions,
-    structs::{boards::Board as GqlBoard, user::User as GqlUser},
+    structs::{
+        boards::Board as GqlBoard,
+        reaction::BoardReactionSettings as GqlBoardReactionSettings,
+        user::User as GqlUser,
+    },
 };
 
 #[derive(Default)]
@@ -217,5 +222,30 @@ impl QueryBoardManagement {
             .collect();
 
         Ok(boards_out)
+    }
+
+    /// Get board reaction settings (public — no auth required).
+    /// Returns `None` when a board has no custom reaction settings,
+    /// meaning the frontend should use the default emoji set.
+    pub async fn get_board_reaction_settings(
+        &self,
+        ctx: &Context<'_>,
+        board_id: ID,
+    ) -> Result<Option<GqlBoardReactionSettings>> {
+        let pool = ctx.data::<DbPool>()?;
+        let conn = &mut get_conn(pool).await?;
+
+        let board_uuid: Uuid = board_id
+            .parse()
+            .map_err(|_| TinyBoardsError::BadRequest("Invalid board ID".to_string()))?;
+
+        let settings: Option<DbBoardReactionSettings> = board_reaction_settings::table
+            .filter(board_reaction_settings::board_id.eq(board_uuid))
+            .first(conn)
+            .await
+            .optional()
+            .map_err(|e| TinyBoardsError::Database(e.to_string()))?;
+
+        Ok(settings.map(GqlBoardReactionSettings::from))
     }
 }

--- a/backend/crates/api/src/structs/reaction.rs
+++ b/backend/crates/api/src/structs/reaction.rs
@@ -62,6 +62,8 @@ pub struct BoardReactionSettings {
     pub emoji_weights: Json<serde_json::Value>,
     #[graphql(name = "reactionsEnabled")]
     pub reactions_enabled: bool,
+    #[graphql(name = "reactionEmojis")]
+    pub reaction_emojis: Json<serde_json::Value>,
 }
 
 impl From<DbBoardReactionSettings> for BoardReactionSettings {
@@ -71,6 +73,7 @@ impl From<DbBoardReactionSettings> for BoardReactionSettings {
             board_id: s.board_id.to_string().into(),
             emoji_weights: Json(s.emoji_weights),
             reactions_enabled: s.is_reactions_enabled,
+            reaction_emojis: Json(s.reaction_emojis),
         }
     }
 }

--- a/backend/crates/db/src/models/reaction.rs
+++ b/backend/crates/db/src/models/reaction.rs
@@ -41,6 +41,7 @@ pub struct BoardReactionSettings {
     pub board_id: Uuid,
     pub emoji_weights: serde_json::Value,
     pub is_reactions_enabled: bool,
+    pub reaction_emojis: serde_json::Value,
 }
 
 #[derive(Debug, Clone, Insertable)]
@@ -49,6 +50,7 @@ pub struct BoardReactionSettingsInsertForm {
     pub board_id: Uuid,
     pub emoji_weights: serde_json::Value,
     pub is_reactions_enabled: bool,
+    pub reaction_emojis: serde_json::Value,
 }
 
 #[derive(Debug, Clone, AsChangeset)]
@@ -56,4 +58,5 @@ pub struct BoardReactionSettingsInsertForm {
 pub struct BoardReactionSettingsUpdateForm {
     pub emoji_weights: Option<serde_json::Value>,
     pub is_reactions_enabled: Option<bool>,
+    pub reaction_emojis: Option<serde_json::Value>,
 }

--- a/backend/crates/db/src/schema.rs
+++ b/backend/crates/db/src/schema.rs
@@ -727,6 +727,7 @@ diesel::table! {
         board_id -> Uuid,
         emoji_weights -> Jsonb,
         is_reactions_enabled -> Bool,
+        reaction_emojis -> Jsonb,
     }
 }
 

--- a/frontend/components/common/ReactionBar.vue
+++ b/frontend/components/common/ReactionBar.vue
@@ -1,18 +1,94 @@
 <script setup lang="ts">
 import { useReactions } from '~/composables/useReactions'
 import { useAuthStore } from '~/stores/auth'
+import { useGraphQL } from '~/composables/useGraphQL'
+
+interface ReactionEmojiEntry {
+  type: 'unicode' | 'custom'
+  value?: string
+  shortcode?: string
+  imageUrl?: string
+}
 
 const props = defineProps<{
   targetType: 'post' | 'comment'
   targetId: string
+  boardId?: string
 }>()
 
 const authStore = useAuthStore()
 const { reactions, acting, toggleReaction, addReaction } = useReactions(props.targetType, props.targetId)
 
 const showPicker = ref(false)
+const settingsLoaded = ref(false)
 
-const defaultEmojis = ['👍', '❤️', '😂', '😮', '😢', '🔥']
+const defaultEmojis: ReactionEmojiEntry[] = [
+  { type: 'unicode', value: '👍' },
+  { type: 'unicode', value: '❤️' },
+  { type: 'unicode', value: '😂' },
+  { type: 'unicode', value: '😮' },
+  { type: 'unicode', value: '😢' },
+  { type: 'unicode', value: '🔥' },
+]
+
+const pickerEmojis = ref<ReactionEmojiEntry[]>([...defaultEmojis])
+
+// Custom emoji lookup for rendering reactions that use :shortcode: format
+const customEmojiMap = ref<Map<string, string>>(new Map())
+
+const REACTION_SETTINGS_QUERY = `
+  query GetBoardReactionSettings($boardId: ID!) {
+    getBoardReactionSettings(boardId: $boardId) {
+      reactionEmojis
+      reactionsEnabled
+    }
+  }
+`
+
+const reactionsEnabled = ref(true)
+
+onMounted(async () => {
+  if (props.boardId) {
+    const { execute } = useGraphQL<{
+      getBoardReactionSettings: {
+        reactionEmojis: ReactionEmojiEntry[]
+        reactionsEnabled: boolean
+      } | null
+    }>()
+    const result = await execute(REACTION_SETTINGS_QUERY, {
+      variables: { boardId: props.boardId },
+    })
+    if (result?.getBoardReactionSettings) {
+      const settings = result.getBoardReactionSettings
+      reactionsEnabled.value = settings.reactionsEnabled
+      if (Array.isArray(settings.reactionEmojis) && settings.reactionEmojis.length > 0) {
+        pickerEmojis.value = settings.reactionEmojis
+        // Build custom emoji lookup
+        for (const entry of settings.reactionEmojis) {
+          if (entry.type === 'custom' && entry.shortcode && entry.imageUrl) {
+            customEmojiMap.value.set(`:${entry.shortcode}:`, entry.imageUrl)
+          }
+        }
+      }
+    }
+  }
+  settingsLoaded.value = true
+})
+
+function emojiKey (entry: ReactionEmojiEntry): string {
+  if (entry.type === 'custom' && entry.shortcode) {
+    return `:${entry.shortcode}:`
+  }
+  return entry.value ?? ''
+}
+
+function isCustomEmoji (emoji: string): boolean {
+  return emoji.startsWith(':') && emoji.endsWith(':') && emoji.length > 2
+}
+
+function getCustomEmojiUrl (emoji: string): string | undefined {
+  return customEmojiMap.value.get(emoji)
+}
 
 async function handleToggle (emoji: string): Promise<void> {
   if (!authStore.isLoggedIn) {
@@ -22,20 +98,21 @@ async function handleToggle (emoji: string): Promise<void> {
   await toggleReaction(emoji)
 }
 
-async function handlePickerSelect (emoji: string): Promise<void> {
+async function handlePickerSelect (entry: ReactionEmojiEntry): Promise<void> {
   showPicker.value = false
   if (!authStore.isLoggedIn) {
     navigateTo('/login')
     return
   }
-  const existing = reactions.value.find(r => r.emoji === emoji)
+  const key = emojiKey(entry)
+  const existing = reactions.value.find(r => r.emoji === key)
   if (existing?.reacted) return
-  await addReaction(emoji)
+  await addReaction(key)
 }
 </script>
 
 <template>
-  <div class="flex items-center gap-1.5 flex-wrap">
+  <div v-if="reactionsEnabled" class="flex items-center gap-1.5 flex-wrap">
     <!-- Existing reactions -->
     <button
       v-for="r in reactions"
@@ -47,7 +124,13 @@ async function handlePickerSelect (emoji: string): Promise<void> {
       :disabled="acting"
       @click="handleToggle(r.emoji)"
     >
-      <span>{{ r.emoji }}</span>
+      <img
+        v-if="isCustomEmoji(r.emoji) && getCustomEmojiUrl(r.emoji)"
+        :src="getCustomEmojiUrl(r.emoji)"
+        :alt="r.emoji"
+        class="w-4 h-4 object-contain"
+      />
+      <span v-else>{{ r.emoji }}</span>
       <span class="font-medium">{{ r.count }}</span>
     </button>
 
@@ -61,18 +144,25 @@ async function handlePickerSelect (emoji: string): Promise<void> {
         +
       </button>
 
-      <!-- Simple emoji picker -->
+      <!-- Emoji picker dropdown -->
       <div
         v-if="showPicker"
         class="absolute bottom-full left-0 mb-1 bg-white border border-gray-200 rounded-lg shadow-lg p-2 z-20 flex gap-1 dropdown-enter"
       >
         <button
-          v-for="emoji in defaultEmojis"
-          :key="emoji"
+          v-for="entry in pickerEmojis"
+          :key="emojiKey(entry)"
           class="w-10 h-10 sm:w-8 sm:h-8 flex items-center justify-center rounded hover:bg-gray-100 text-base"
-          @click="handlePickerSelect(emoji)"
+          :title="entry.type === 'custom' ? `:${entry.shortcode}:` : entry.value"
+          @click="handlePickerSelect(entry)"
         >
-          {{ emoji }}
+          <img
+            v-if="entry.type === 'custom' && entry.imageUrl"
+            :src="entry.imageUrl"
+            :alt="entry.shortcode ?? ''"
+            class="w-6 h-6 object-contain"
+          />
+          <span v-else>{{ entry.value }}</span>
         </button>
       </div>
     </div>

--- a/frontend/components/post/PostDetail.vue
+++ b/frontend/components/post/PostDetail.vue
@@ -379,7 +379,7 @@ function onClickOutsideMenu (e: Event): void {
 
         <!-- Reactions (threads only) -->
         <div v-if="post.isThread" class="mt-3">
-          <CommonReactionBar target-type="post" :target-id="post.id" />
+          <CommonReactionBar target-type="post" :target-id="post.id" :board-id="post.board?.id" />
         </div>
       </div>
     </div>

--- a/frontend/components/thread/ThreadDetailHeader.vue
+++ b/frontend/components/thread/ThreadDetailHeader.vue
@@ -263,7 +263,7 @@ function openRemoveDialog (): void {
     <!-- Footer: unified actions -->
     <div class="px-4 py-2 bg-gray-50 border-t border-gray-100 flex items-center justify-between flex-wrap gap-2">
       <!-- Left: reactions -->
-      <CommonReactionBar target-type="post" :target-id="post.id" />
+      <CommonReactionBar target-type="post" :target-id="post.id" :board-id="post.board?.id" />
 
       <!-- Right: actions -->
       <div class="flex items-center gap-1 text-xs text-gray-500">

--- a/frontend/components/thread/ThreadPost.vue
+++ b/frontend/components/thread/ThreadPost.vue
@@ -13,6 +13,7 @@ const props = defineProps<{
   postId: string
   postNumber: number
   isModerator?: boolean
+  boardId?: string
 }>()
 
 const emit = defineEmits<{
@@ -165,7 +166,7 @@ async function togglePin (): Promise<void> {
     <!-- Post footer -->
     <div class="px-4 py-2 bg-gray-50 border-t border-gray-100 flex items-center justify-between flex-wrap gap-2">
       <!-- Left: reactions -->
-      <CommonReactionBar target-type="comment" :target-id="comment.id" />
+      <CommonReactionBar target-type="comment" :target-id="comment.id" :board-id="boardId" />
 
       <!-- Right: actions -->
       <div class="flex items-center gap-1 text-xs text-gray-500">

--- a/frontend/composables/useEmoji.ts
+++ b/frontend/composables/useEmoji.ts
@@ -1,17 +1,19 @@
 import { ref } from 'vue'
 import { useGraphQL } from '~/composables/useGraphQL'
 
-interface CustomEmoji {
+export interface CustomEmoji {
   id: string
   shortcode: string
   imageUrl: string
   category: string | null
+  scope?: string
+  boardId?: string | null
 }
 
 const EMOJIS_QUERY = `
-  query ListEmojis {
-    listEmojis {
-      id shortcode imageUrl category
+  query ListEmojis($input: ListEmojisInput) {
+    listEmojis(input: $input) {
+      id shortcode imageUrl category scope boardId
     }
   }
 `
@@ -20,8 +22,33 @@ export function useEmoji () {
   const { execute, loading, error } = useGraphQL<{ listEmojis: CustomEmoji[] }>()
   const emojis = ref<CustomEmoji[]>([])
 
+  /** Fetch all site-wide custom emojis (no board filter). */
   async function fetchEmojis (): Promise<void> {
     const result = await execute(EMOJIS_QUERY)
+    if (result?.listEmojis) {
+      emojis.value = result.listEmojis
+    }
+  }
+
+  /** Fetch emojis scoped to a specific board only (not site-wide). */
+  async function fetchBoardEmojis (boardId: string): Promise<void> {
+    const result = await execute(EMOJIS_QUERY, {
+      variables: { input: { boardId, scope: 'Board' } },
+    })
+    if (result?.listEmojis) {
+      emojis.value = result.listEmojis
+    }
+  }
+
+  /** Fetch all emojis available in a board context (site-wide + board-specific). */
+  async function fetchAllAvailableEmojis (boardId?: string): Promise<void> {
+    const input: Record<string, unknown> = {}
+    if (boardId) {
+      input.boardId = boardId
+    }
+    const result = await execute(EMOJIS_QUERY, {
+      variables: { input },
+    })
     if (result?.listEmojis) {
       emojis.value = result.listEmojis
     }
@@ -36,6 +63,8 @@ export function useEmoji () {
     loading,
     error,
     fetchEmojis,
+    fetchBoardEmojis,
+    fetchAllAvailableEmojis,
     findEmoji,
   }
 }

--- a/frontend/pages/b/[board]/[id]/[[slug]].vue
+++ b/frontend/pages/b/[board]/[id]/[[slug]].vue
@@ -226,6 +226,7 @@ function handleQuoteOP (author: string, body: string): void {
             :post-id="postId"
             :post-number="index + 2"
             :is-moderator="isModerator"
+            :board-id="post.board?.id"
             @quote="handleQuoteFromComment"
           />
         </div>

--- a/frontend/pages/b/[board]/settings/appearance.vue
+++ b/frontend/pages/b/[board]/settings/appearance.vue
@@ -208,6 +208,12 @@ async function saveSettings () {
       >
         Moderation
       </NuxtLink>
+      <NuxtLink
+        :to="`/b/${boardName}/settings/emojis`"
+        class="px-3 py-1.5 text-sm font-medium border-b-2 no-underline transition-colors border-transparent text-gray-500 hover:text-gray-700"
+      >
+        Emojis
+      </NuxtLink>
     </div>
 
     <h2 class="text-base font-semibold text-gray-900 mb-4">

--- a/frontend/pages/b/[board]/settings/emojis.vue
+++ b/frontend/pages/b/[board]/settings/emojis.vue
@@ -1,0 +1,635 @@
+<script setup lang="ts">
+import { useGraphQL, useGraphQLMutation } from '~/composables/useGraphQL'
+import { useFileUpload } from '~/composables/useFileUpload'
+import { useToast } from '~/composables/useToast'
+import { unicodeEmojis } from '~/data/emojis'
+
+definePageMeta({ middleware: 'guards' })
+
+const route = useRoute()
+const boardName = route.params.board as string
+const toast = useToast()
+
+useHead({ title: `Emojis - b/${boardName}` })
+
+// ============================================================
+// Types
+// ============================================================
+
+interface ReactionEmojiEntry {
+  type: 'unicode' | 'custom'
+  value?: string
+  shortcode?: string
+  imageUrl?: string
+}
+
+interface EmojiObject {
+  id: string
+  shortcode: string
+  imageUrl: string
+  altText: string
+  category: string
+  scope: string
+  boardId: string | null
+  isActive: boolean
+  createdAt: string
+}
+
+// ============================================================
+// GraphQL queries/mutations
+// ============================================================
+
+const BOARD_QUERY = `
+  query GetBoard($name: String!) {
+    board(name: $name) { id }
+  }
+`
+
+const REACTION_SETTINGS_QUERY = `
+  query GetBoardReactionSettings($boardId: ID!) {
+    getBoardReactionSettings(boardId: $boardId) {
+      id boardId reactionEmojis reactionsEnabled
+    }
+  }
+`
+
+const UPDATE_REACTION_SETTINGS = `
+  mutation UpdateBoardReactionSettings($input: UpdateBoardReactionSettingsInput!) {
+    updateBoardReactionSettings(input: $input) {
+      settings { id reactionEmojis reactionsEnabled }
+    }
+  }
+`
+
+const LIST_BOARD_EMOJIS = `
+  query ListBoardEmojis($input: ListEmojisInput) {
+    listEmojis(input: $input) {
+      id shortcode imageUrl altText category scope boardId isActive createdAt
+    }
+  }
+`
+
+const LIST_ALL_EMOJIS = `
+  query ListAllEmojis($input: ListEmojisInput) {
+    listEmojis(input: $input) {
+      id shortcode imageUrl category scope boardId
+    }
+  }
+`
+
+const CREATE_EMOJI = `
+  mutation CreateEmoji($input: CreateEmojiInput!) {
+    createEmoji(input: $input) {
+      id shortcode imageUrl altText category scope boardId isActive createdAt
+    }
+  }
+`
+
+const UPLOAD_EMOJI = `
+  mutation UploadEmoji($shortcode: String!, $file: Upload!, $category: String, $boardId: ID, $scope: EmojiScope) {
+    uploadEmoji(shortcode: $shortcode, file: $file, category: $category, boardId: $boardId, scope: $scope) {
+      id shortcode imageUrl altText category scope boardId isActive createdAt
+    }
+  }
+`
+
+const DELETE_EMOJI = `
+  mutation DeleteEmoji($emojiId: ID!) {
+    deleteEmoji(emojiId: $emojiId)
+  }
+`
+
+// ============================================================
+// State
+// ============================================================
+
+const { execute, loading } = useGraphQL()
+const { execute: executeMutation, loading: saving } = useGraphQLMutation()
+const { executeWithFile, uploading } = useFileUpload()
+const { execute: executeDelete, loading: deleting } = useGraphQLMutation()
+
+const boardId = ref<string | null>(null)
+
+// --- Reaction emoji config ---
+const reactionEmojis = ref<ReactionEmojiEntry[]>([])
+const reactionsEnabled = ref(true)
+const showEmojiSelector = ref(false)
+const emojiSearch = ref('')
+
+// Available custom emojis (site-wide + board-specific)
+const availableCustomEmojis = ref<EmojiObject[]>([])
+
+// --- Board emoji management ---
+const boardEmojis = ref<EmojiObject[]>([])
+const newShortcode = ref('')
+const newImageUrl = ref('')
+const inputMode = ref<'upload' | 'url'>('upload')
+const fileInput = ref<HTMLInputElement | null>(null)
+const selectedFile = ref<File | null>(null)
+const filePreview = ref<string | null>(null)
+const createError = ref<string | null>(null)
+
+// ============================================================
+// Lifecycle
+// ============================================================
+
+onMounted(async () => {
+  const { execute: execBoard } = useGraphQL<{ board: { id: string } }>()
+  const boardResult = await execBoard(BOARD_QUERY, { variables: { name: boardName } })
+  if (!boardResult?.board) return
+  boardId.value = boardResult.board.id
+  await Promise.all([loadReactionSettings(), loadBoardEmojis(), loadAvailableEmojis()])
+})
+
+// ============================================================
+// Reaction settings
+// ============================================================
+
+async function loadReactionSettings () {
+  if (!boardId.value) return
+  const { execute: exec } = useGraphQL<{
+    getBoardReactionSettings: {
+      reactionEmojis: ReactionEmojiEntry[]
+      reactionsEnabled: boolean
+    } | null
+  }>()
+  const result = await exec(REACTION_SETTINGS_QUERY, { variables: { boardId: boardId.value } })
+  if (result?.getBoardReactionSettings) {
+    const s = result.getBoardReactionSettings
+    reactionsEnabled.value = s.reactionsEnabled
+    if (Array.isArray(s.reactionEmojis) && s.reactionEmojis.length > 0) {
+      reactionEmojis.value = s.reactionEmojis
+    }
+  }
+}
+
+async function saveReactionSettings () {
+  if (!boardId.value) return
+  const result = await executeMutation(UPDATE_REACTION_SETTINGS, {
+    variables: {
+      input: {
+        boardId: boardId.value,
+        isReactionsEnabled: reactionsEnabled.value,
+        reactionEmojis: reactionEmojis.value,
+      },
+    },
+  })
+  if (result) {
+    toast.success('Reaction settings saved')
+  }
+}
+
+function removeReactionEmoji (index: number) {
+  reactionEmojis.value.splice(index, 1)
+}
+
+function addUnicodeReaction (emoji: string) {
+  if (reactionEmojis.value.length >= 10) {
+    toast.error('Maximum 10 reaction emojis')
+    return
+  }
+  // Check for duplicate
+  if (reactionEmojis.value.some(e => e.type === 'unicode' && e.value === emoji)) return
+  reactionEmojis.value.push({ type: 'unicode', value: emoji })
+  showEmojiSelector.value = false
+  emojiSearch.value = ''
+}
+
+function addCustomReaction (emoji: EmojiObject) {
+  if (reactionEmojis.value.length >= 10) {
+    toast.error('Maximum 10 reaction emojis')
+    return
+  }
+  if (reactionEmojis.value.some(e => e.type === 'custom' && e.shortcode === emoji.shortcode)) return
+  reactionEmojis.value.push({
+    type: 'custom',
+    shortcode: emoji.shortcode,
+    imageUrl: emoji.imageUrl,
+  })
+  showEmojiSelector.value = false
+  emojiSearch.value = ''
+}
+
+function resetToDefaults () {
+  reactionEmojis.value = []
+}
+
+const filteredUnicodeEmojis = computed(() => {
+  if (!emojiSearch.value) return unicodeEmojis.slice(0, 50)
+  const q = emojiSearch.value.toLowerCase()
+  return unicodeEmojis.filter(e =>
+    e.shortcode.includes(q) || e.keywords.some(k => k.includes(q)),
+  ).slice(0, 50)
+})
+
+const filteredCustomEmojis = computed(() => {
+  if (!emojiSearch.value) return availableCustomEmojis.value
+  const q = emojiSearch.value.toLowerCase()
+  return availableCustomEmojis.value.filter(e => e.shortcode.includes(q))
+})
+
+// ============================================================
+// Board emoji management
+// ============================================================
+
+async function loadBoardEmojis () {
+  if (!boardId.value) return
+  const { execute: exec } = useGraphQL<{ listEmojis: EmojiObject[] }>()
+  const result = await exec(LIST_BOARD_EMOJIS, {
+    variables: { input: { boardId: boardId.value, scope: 'Board' } },
+  })
+  if (result?.listEmojis) {
+    boardEmojis.value = result.listEmojis
+  }
+}
+
+async function loadAvailableEmojis () {
+  if (!boardId.value) return
+  const { execute: exec } = useGraphQL<{ listEmojis: EmojiObject[] }>()
+  const result = await exec(LIST_ALL_EMOJIS, {
+    variables: { input: { boardId: boardId.value, limit: 200 } },
+  })
+  if (result?.listEmojis) {
+    availableCustomEmojis.value = result.listEmojis
+  }
+}
+
+function onFileSelected (event: Event) {
+  const target = event.target as HTMLInputElement
+  const file = target.files?.[0]
+  if (!file) return
+  selectedFile.value = file
+  const reader = new FileReader()
+  reader.onload = (e) => { filePreview.value = e.target?.result as string }
+  reader.readAsDataURL(file)
+}
+
+function clearFile () {
+  selectedFile.value = null
+  filePreview.value = null
+  if (fileInput.value) fileInput.value.value = ''
+}
+
+async function createBoardEmoji () {
+  if (!boardId.value || !newShortcode.value.trim()) return
+  createError.value = null
+
+  if (inputMode.value === 'upload') {
+    if (!selectedFile.value) return
+    const result = await executeWithFile(
+      UPLOAD_EMOJI,
+      {
+        shortcode: newShortcode.value.trim(),
+        boardId: boardId.value,
+        scope: 'Board',
+        category: 'custom',
+      },
+      'file',
+      selectedFile.value,
+    )
+    if (result?.uploadEmoji) {
+      newShortcode.value = ''
+      clearFile()
+      await Promise.all([loadBoardEmojis(), loadAvailableEmojis()])
+      toast.success('Board emoji created')
+    }
+  } else {
+    if (!newImageUrl.value.trim()) return
+    const { execute: exec } = useGraphQLMutation<{ createEmoji: EmojiObject }>()
+    const result = await exec(CREATE_EMOJI, {
+      variables: {
+        input: {
+          shortcode: newShortcode.value.trim(),
+          imageUrl: newImageUrl.value.trim(),
+          altText: newShortcode.value.trim(),
+          category: 'custom',
+          boardId: boardId.value,
+          scope: 'Board',
+        },
+      },
+    })
+    if (result?.createEmoji) {
+      newShortcode.value = ''
+      newImageUrl.value = ''
+      await Promise.all([loadBoardEmojis(), loadAvailableEmojis()])
+      toast.success('Board emoji created')
+    }
+  }
+}
+
+async function deleteBoardEmoji (id: string) {
+  await executeDelete(DELETE_EMOJI, { variables: { emojiId: id } })
+  await Promise.all([loadBoardEmojis(), loadAvailableEmojis()])
+  toast.success('Emoji deleted')
+}
+
+const formValid = computed(() => {
+  if (!newShortcode.value.trim()) return false
+  if (inputMode.value === 'upload') return !!selectedFile.value
+  return !!newImageUrl.value.trim()
+})
+const formBusy = computed(() => uploading.value)
+</script>
+
+<template>
+  <div>
+    <!-- Settings sub-navigation -->
+    <div class="flex gap-1 border-b border-gray-200 mb-4">
+      <NuxtLink
+        :to="`/b/${boardName}/settings`"
+        class="px-3 py-1.5 text-sm font-medium border-b-2 no-underline transition-colors border-transparent text-gray-500 hover:text-gray-700"
+      >
+        General
+      </NuxtLink>
+      <NuxtLink
+        :to="`/b/${boardName}/settings/appearance`"
+        class="px-3 py-1.5 text-sm font-medium border-b-2 no-underline transition-colors border-transparent text-gray-500 hover:text-gray-700"
+      >
+        Appearance
+      </NuxtLink>
+      <NuxtLink
+        :to="`/b/${boardName}/settings/moderation`"
+        class="px-3 py-1.5 text-sm font-medium border-b-2 no-underline transition-colors border-transparent text-gray-500 hover:text-gray-700"
+      >
+        Moderation
+      </NuxtLink>
+      <NuxtLink
+        :to="`/b/${boardName}/settings/emojis`"
+        class="px-3 py-1.5 text-sm font-medium border-b-2 no-underline transition-colors border-blue-600 text-blue-600"
+      >
+        Emojis
+      </NuxtLink>
+    </div>
+
+    <CommonLoadingSpinner v-if="loading && !boardId" size="lg" />
+
+    <div v-else class="space-y-8 max-w-3xl">
+      <!-- ============================================================ -->
+      <!-- Section A: Reaction Emojis Configuration -->
+      <!-- ============================================================ -->
+      <section>
+        <h2 class="text-base font-semibold text-gray-900 mb-1">
+          Reaction Emojis
+        </h2>
+        <p class="text-xs text-gray-500 mb-4">
+          Choose which emojis appear as quick-reaction buttons on posts and comments. Leave empty to use the site defaults.
+        </p>
+
+        <!-- Reactions enabled toggle -->
+        <label class="flex items-center gap-2 mb-4">
+          <input v-model="reactionsEnabled" type="checkbox" class="form-checkbox" />
+          <span class="text-sm text-gray-700">Enable reactions on this board</span>
+        </label>
+
+        <!-- Current reaction emojis -->
+        <div class="bg-white border border-gray-200 rounded-lg p-4 mb-4">
+          <div class="flex items-center gap-2 flex-wrap min-h-[2.5rem]">
+            <div
+              v-for="(entry, idx) in reactionEmojis"
+              :key="idx"
+              class="group relative inline-flex items-center gap-1 px-2.5 py-1 rounded-full border border-gray-200 bg-gray-50 text-sm"
+            >
+              <img
+                v-if="entry.type === 'custom' && entry.imageUrl"
+                :src="entry.imageUrl"
+                :alt="entry.shortcode"
+                class="w-5 h-5 object-contain"
+              />
+              <span v-else>{{ entry.value }}</span>
+              <span v-if="entry.type === 'custom'" class="text-xs text-gray-400">
+                :{{ entry.shortcode }}:
+              </span>
+              <button
+                class="ml-0.5 text-gray-300 hover:text-red-500 transition-colors"
+                title="Remove"
+                @click="removeReactionEmoji(idx)"
+              >
+                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+
+            <span v-if="reactionEmojis.length === 0" class="text-xs text-gray-400 italic">
+              Using site defaults (👍 ❤️ 😂 😮 😢 🔥)
+            </span>
+
+            <!-- Add button -->
+            <button
+              v-if="reactionEmojis.length < 10"
+              class="inline-flex items-center px-2 py-1 rounded-full text-xs border border-dashed border-gray-300 text-gray-400 hover:text-gray-600 hover:border-gray-400 transition-colors"
+              @click="showEmojiSelector = !showEmojiSelector"
+            >
+              + Add
+            </button>
+          </div>
+        </div>
+
+        <!-- Emoji selector popup -->
+        <div v-if="showEmojiSelector" class="bg-white border border-gray-200 rounded-lg shadow-lg p-4 mb-4">
+          <div class="flex items-center justify-between mb-3">
+            <span class="text-sm font-medium text-gray-700">Select an Emoji</span>
+            <button class="text-xs text-gray-400 hover:text-gray-600" @click="showEmojiSelector = false">Close</button>
+          </div>
+          <input
+            v-model="emojiSearch"
+            type="text"
+            class="form-input w-full mb-3 text-sm"
+            placeholder="Search emojis..."
+          />
+
+          <!-- Custom emojis section -->
+          <div v-if="filteredCustomEmojis.length > 0" class="mb-3">
+            <h4 class="text-xs font-medium text-gray-500 uppercase tracking-wide mb-2">Custom Emojis</h4>
+            <div class="flex flex-wrap gap-1.5 max-h-32 overflow-y-auto">
+              <button
+                v-for="emoji in filteredCustomEmojis"
+                :key="emoji.id"
+                class="w-9 h-9 flex items-center justify-center rounded hover:bg-gray-100 border border-transparent hover:border-gray-200 transition-colors"
+                :title="`:${emoji.shortcode}:`"
+                @click="addCustomReaction(emoji)"
+              >
+                <img :src="emoji.imageUrl" :alt="emoji.shortcode" class="w-6 h-6 object-contain" />
+              </button>
+            </div>
+          </div>
+
+          <!-- Unicode emojis section -->
+          <div>
+            <h4 class="text-xs font-medium text-gray-500 uppercase tracking-wide mb-2">Unicode Emojis</h4>
+            <div class="flex flex-wrap gap-1 max-h-40 overflow-y-auto">
+              <button
+                v-for="ue in filteredUnicodeEmojis"
+                :key="ue.shortcode"
+                class="w-9 h-9 flex items-center justify-center rounded hover:bg-gray-100 text-lg transition-colors"
+                :title="`:${ue.shortcode}:`"
+                @click="addUnicodeReaction(ue.emoji)"
+              >
+                {{ ue.emoji }}
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <!-- Action buttons -->
+        <div class="flex gap-2">
+          <button
+            class="button primary"
+            :disabled="saving"
+            @click="saveReactionSettings"
+          >
+            {{ saving ? 'Saving...' : 'Save Reaction Settings' }}
+          </button>
+          <button
+            v-if="reactionEmojis.length > 0"
+            class="button white"
+            @click="resetToDefaults"
+          >
+            Reset to Defaults
+          </button>
+        </div>
+      </section>
+
+      <!-- ============================================================ -->
+      <!-- Section B: Board Custom Emojis -->
+      <!-- ============================================================ -->
+      <section>
+        <h2 class="text-base font-semibold text-gray-900 mb-1">
+          Board Emojis
+        </h2>
+        <p class="text-xs text-gray-500 mb-4">
+          Custom emojis uploaded here are only available within this board. Site-wide emojis are managed by site administrators and are available everywhere.
+        </p>
+
+        <!-- Add emoji form -->
+        <div class="bg-white rounded-lg border border-gray-200 p-4 mb-6 max-w-lg">
+          <h3 class="text-sm font-medium text-gray-900 mb-3">
+            Add Board Emoji
+          </h3>
+          <form class="space-y-3" @submit.prevent="createBoardEmoji">
+            <div>
+              <label class="block text-sm font-medium text-gray-700 mb-1">Shortcode</label>
+              <input
+                v-model="newShortcode"
+                type="text"
+                class="form-input w-full"
+                placeholder="e.g. board_mascot"
+                pattern="[a-z0-9_]+"
+              />
+              <p class="mt-1 text-xs text-gray-500">Lowercase letters, numbers, and underscores only.</p>
+            </div>
+
+            <!-- Input mode toggle -->
+            <div class="flex gap-2">
+              <button
+                type="button"
+                class="px-3 py-1 text-xs rounded-full border transition-colors"
+                :class="inputMode === 'upload'
+                  ? 'bg-primary text-white border-primary'
+                  : 'bg-white text-gray-600 border-gray-300 hover:border-gray-400'"
+                @click="inputMode = 'upload'"
+              >
+                Upload File
+              </button>
+              <button
+                type="button"
+                class="px-3 py-1 text-xs rounded-full border transition-colors"
+                :class="inputMode === 'url'
+                  ? 'bg-primary text-white border-primary'
+                  : 'bg-white text-gray-600 border-gray-300 hover:border-gray-400'"
+                @click="inputMode = 'url'"
+              >
+                Image URL
+              </button>
+            </div>
+
+            <!-- File upload -->
+            <div v-if="inputMode === 'upload'">
+              <label class="block text-sm font-medium text-gray-700 mb-1">Emoji Image</label>
+              <div class="flex items-center gap-3">
+                <label class="cursor-pointer inline-flex items-center gap-2 px-3 py-1.5 text-sm border border-gray-300 rounded-md hover:bg-gray-50 transition-colors">
+                  <svg class="w-4 h-4 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                  </svg>
+                  Choose file
+                  <input
+                    ref="fileInput"
+                    type="file"
+                    accept="image/png,image/gif,image/webp,image/jpeg"
+                    class="hidden"
+                    @change="onFileSelected"
+                  />
+                </label>
+                <div v-if="selectedFile" class="flex items-center gap-2">
+                  <img v-if="filePreview" :src="filePreview" alt="Preview" class="w-8 h-8 object-contain rounded border border-gray-200" />
+                  <span class="text-sm text-gray-600 truncate max-w-[150px]">{{ selectedFile.name }}</span>
+                  <button type="button" class="text-gray-400 hover:text-red-500 transition-colors" @click="clearFile">
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+              <p class="mt-1 text-xs text-gray-500">PNG, GIF, WebP, or JPEG. Max 512x512 pixels.</p>
+            </div>
+
+            <!-- URL input -->
+            <div v-else>
+              <label class="block text-sm font-medium text-gray-700 mb-1">Image URL</label>
+              <input
+                v-model="newImageUrl"
+                type="url"
+                class="form-input w-full"
+                placeholder="https://example.com/emoji.png"
+              />
+              <p class="mt-1 text-xs text-gray-500">URL to the emoji image (PNG, GIF, or WebP).</p>
+            </div>
+
+            <div v-if="createError" class="text-sm text-red-600">{{ createError }}</div>
+
+            <button
+              type="submit"
+              class="button primary"
+              :disabled="formBusy || !formValid"
+            >
+              {{ formBusy ? 'Adding...' : 'Add Emoji' }}
+            </button>
+          </form>
+        </div>
+
+        <!-- Board emoji list -->
+        <h3 class="text-sm font-medium text-gray-500 uppercase tracking-wide mb-3">
+          Board Emojis ({{ boardEmojis.length }})
+        </h3>
+
+        <div v-if="boardEmojis.length === 0" class="text-sm text-gray-500">
+          No board-specific emojis yet. Emojis uploaded here will only be available within this board.
+        </div>
+
+        <div v-else class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+          <div
+            v-for="emoji in boardEmojis"
+            :key="emoji.id"
+            class="bg-white rounded-lg border border-gray-200 p-3 flex items-center gap-3"
+          >
+            <img
+              :src="emoji.imageUrl"
+              :alt="emoji.shortcode"
+              class="w-8 h-8 object-contain"
+            />
+            <span class="text-sm font-mono text-gray-700 flex-1 truncate">
+              :{{ emoji.shortcode }}:
+            </span>
+            <button
+              class="button button-sm red shrink-0"
+              :disabled="deleting"
+              @click="deleteBoardEmoji(emoji.id)"
+            >
+              Delete
+            </button>
+          </div>
+        </div>
+      </section>
+    </div>
+  </div>
+</template>

--- a/frontend/pages/b/[board]/settings/index.vue
+++ b/frontend/pages/b/[board]/settings/index.vue
@@ -184,6 +184,12 @@ async function saveSettings () {
       >
         Moderation
       </NuxtLink>
+      <NuxtLink
+        :to="`/b/${boardName}/settings/emojis`"
+        class="px-3 py-1.5 text-sm font-medium border-b-2 no-underline transition-colors border-transparent text-gray-500 hover:text-gray-700"
+      >
+        Emojis
+      </NuxtLink>
     </div>
 
     <h2 class="text-base font-semibold text-gray-900 mb-4">

--- a/frontend/pages/b/[board]/settings/moderation.vue
+++ b/frontend/pages/b/[board]/settings/moderation.vue
@@ -202,6 +202,12 @@ function formatDate (dateStr: string): string {
       >
         Moderation
       </NuxtLink>
+      <NuxtLink
+        :to="`/b/${boardName}/settings/emojis`"
+        class="px-3 py-1.5 text-sm font-medium border-b-2 no-underline transition-colors border-transparent text-gray-500 hover:text-gray-700"
+      >
+        Emojis
+      </NuxtLink>
     </div>
 
     <h2 class="text-base font-semibold text-gray-900 mb-4">

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -122,6 +122,9 @@ type Query {
   listEmojis(input: ListEmojisInput): [EmojiObject!]!
   getAllEmojisAdmin(boardId: ID): [EmojiObject!]!
 
+  # Board reaction settings (public)
+  getBoardReactionSettings(boardId: ID!): BoardReactionSettings
+
   # Flairs
   boardFlairs(boardId: ID!, flairType: FlairType, activeOnly: Boolean): [FlairTemplate!]!
   manageBoardFlairs(boardId: ID!, flairType: FlairType): [FlairTemplate!]!
@@ -250,7 +253,14 @@ type Mutation {
 
   # Emojis
   createEmoji(input: CreateEmojiInput!): EmojiObject!
+  updateEmoji(emojiId: ID!, input: UpdateEmojiInput!): EmojiObject!
+  uploadEmoji(shortcode: String!, file: Upload!, category: String, boardId: ID, scope: EmojiScope): EmojiObject!
   deleteEmoji(emojiId: ID!): Boolean!
+
+  # Reactions
+  addReaction(input: AddReactionInput!): AddReactionResponse!
+  removeReaction(input: RemoveReactionInput!): RemoveReactionResponse!
+  updateBoardReactionSettings(input: UpdateBoardReactionSettingsInput!): UpdateBoardReactionSettingsResponse!
 
   # Board bans
   banUserFromBoard(input: BoardBanUserInput!): BoardBanResponse!
@@ -1044,6 +1054,76 @@ input ListEmojisInput {
 enum EmojiScope {
   Site
   Board
+}
+
+input UpdateEmojiInput {
+  shortcode: String
+  imageUrl: String
+  altText: String
+  category: String
+  isActive: Boolean
+  keywords: [String!]
+}
+
+# ============================================================
+# Reaction types
+# ============================================================
+
+type Reaction {
+  id: ID!
+  userId: ID!
+  postId: ID
+  commentId: ID
+  emoji: String!
+  score: Int!
+  createdAt: String!
+}
+
+type ReactionAggregate {
+  id: ID!
+  postId: ID
+  commentId: ID
+  emoji: String!
+  count: Int!
+}
+
+type BoardReactionSettings {
+  id: ID!
+  boardId: ID!
+  emojiWeights: JSON!
+  reactionsEnabled: Boolean!
+  reactionEmojis: JSON!
+}
+
+type AddReactionResponse {
+  reaction: Reaction!
+}
+
+type RemoveReactionResponse {
+  success: Boolean!
+}
+
+type UpdateBoardReactionSettingsResponse {
+  settings: BoardReactionSettings!
+}
+
+input AddReactionInput {
+  postId: ID
+  commentId: ID
+  emoji: String!
+}
+
+input RemoveReactionInput {
+  postId: ID
+  commentId: ID
+  emoji: String!
+}
+
+input UpdateBoardReactionSettingsInput {
+  boardId: ID!
+  emojiWeights: JSON
+  isReactionsEnabled: Boolean
+  reactionEmojis: JSON
 }
 
 # ============================================================

--- a/frontend/types/generated.ts
+++ b/frontend/types/generated.ts
@@ -152,6 +152,7 @@ export type BoardReactionSettings = {
   boardId: Scalars['ID']['output'];
   emojiWeights: Scalars['JSON']['output'];
   id: Scalars['ID']['output'];
+  reactionEmojis: Scalars['JSON']['output'];
   reactionsEnabled: Scalars['Boolean']['output'];
 };
 
@@ -1261,6 +1262,7 @@ export type Query = {
   getAllEmojisAdmin: Array<EmojiObject>;
   getBoardBannedUsers: Array<BoardBannedUser>;
   getBoardModerators: Array<BoardModerator>;
+  getBoardReactionSettings?: Maybe<BoardReactionSettings>;
   getBoardSettings: BoardSettings;
   getCommentReports: Array<CommentReportView>;
   getConversation: Array<PrivateMessage>;
@@ -1348,6 +1350,11 @@ export type QueryGetBoardBannedUsersArgs = {
 
 
 export type QueryGetBoardModeratorsArgs = {
+  boardId: Scalars['ID']['input'];
+};
+
+
+export type QueryGetBoardReactionSettingsArgs = {
   boardId: Scalars['ID']['input'];
 };
 
@@ -1671,6 +1678,7 @@ export type UpdateBoardReactionSettingsInput = {
   boardId: Scalars['ID']['input'];
   emojiWeights?: InputMaybe<Scalars['JSON']['input']>;
   isReactionsEnabled?: InputMaybe<Scalars['Boolean']['input']>;
+  reactionEmojis?: InputMaybe<Scalars['JSON']['input']>;
 };
 
 export type UpdateBoardReactionSettingsResponse = {

--- a/migrations/2026-04-10-000023_board_reaction_emojis/down.sql
+++ b/migrations/2026-04-10-000023_board_reaction_emojis/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE board_reaction_settings DROP COLUMN reaction_emojis;

--- a/migrations/2026-04-10-000023_board_reaction_emojis/up.sql
+++ b/migrations/2026-04-10-000023_board_reaction_emojis/up.sql
@@ -1,0 +1,7 @@
+-- Add reaction_emojis column to board_reaction_settings
+-- Stores the list of emojis shown in the quick-reaction picker for a board.
+-- Empty array means "use site defaults" (the 6 hardcoded unicode emojis).
+-- Each entry: {"type":"unicode","value":"👍"} or {"type":"custom","shortcode":"party_parrot","imageUrl":"https://..."}
+
+ALTER TABLE board_reaction_settings
+  ADD COLUMN reaction_emojis JSONB NOT NULL DEFAULT '[]';

--- a/schema.graphql
+++ b/schema.graphql
@@ -122,6 +122,9 @@ type Query {
   listEmojis(input: ListEmojisInput): [EmojiObject!]!
   getAllEmojisAdmin(boardId: ID): [EmojiObject!]!
 
+  # Board reaction settings (public)
+  getBoardReactionSettings(boardId: ID!): BoardReactionSettings
+
   # Flairs
   boardFlairs(boardId: ID!, flairType: FlairType, activeOnly: Boolean): [FlairTemplate!]!
   manageBoardFlairs(boardId: ID!, flairType: FlairType): [FlairTemplate!]!
@@ -1195,6 +1198,7 @@ type BoardReactionSettings {
   boardId: ID!
   emojiWeights: JSON!
   reactionsEnabled: Boolean!
+  reactionEmojis: JSON!
 }
 
 type AddReactionResponse {
@@ -1225,6 +1229,7 @@ input UpdateBoardReactionSettingsInput {
   boardId: ID!
   emojiWeights: JSON
   isReactionsEnabled: Boolean
+  reactionEmojis: JSON
 }
 
 # ============================================================


### PR DESCRIPTION
…moji management

Add per-board reaction emoji configuration so moderators can customize which emojis appear in the quick-reaction picker. Also adds board-level custom emoji management (upload/delete board-only emojis) and integrates custom emoji rendering into the ReactionBar component.

Backend:
- Migration 000023: add reaction_emojis JSONB column to board_reaction_settings
- New getBoardReactionSettings public query for fetching board emoji config
- Validation for reaction_emojis JSON structure in updateBoardReactionSettings
- Support custom emoji entries alongside unicode in reaction settings

Frontend:
- ReactionBar accepts boardId prop, fetches board-specific reaction emojis
- Renders custom emojis as images in both picker and reaction pills
- New board settings Emojis tab with reaction config and emoji management
- Updated useEmoji composable with board-scoped fetching
- Added Emojis tab to all board settings sub-navigation pages