### PR TITLE
Add GraphQL name attributes to EmojiScope enum variants

### DIFF
--- a/backend/crates/api/src/structs/emoji.rs
+++ b/backend/crates/api/src/structs/emoji.rs
@@ -65,7 +65,9 @@ pub struct UpdateEmojiInput {
 
 #[derive(Enum, Copy, Clone, Eq, PartialEq)]
 pub enum EmojiScope {
+    #[graphql(name = "Site")]
     Site,
+    #[graphql(name = "Board")]
     Board,
 }
 


### PR DESCRIPTION
## Summary
Added explicit GraphQL name attributes to the `EmojiScope` enum variants to ensure proper naming in the GraphQL schema.

## Changes
- Added `#[graphql(name = "Site")]` attribute to the `Site` variant
- Added `#[graphql(name = "Board")]` attribute to the `Board` variant

## Details
These GraphQL name attributes explicitly define how each enum variant should be represented in the GraphQL schema. This ensures consistent naming conventions and prevents any potential naming mismatches between the Rust code and the generated GraphQL API