### PR TITLE
feat(posts): add mod/admin NSFW toggle and blur treatment for NSFW co…

### DIFF
--- a/backend/crates/api/src/mutations/post/moderation.rs
+++ b/backend/crates/api/src/mutations/post/moderation.rs
@@ -320,4 +320,100 @@ impl PostModeration {
             .await
             .map_err(|e| e.into())
     }
+
+    /// Mark a post as NSFW (mod/admin action)
+    pub async fn mark_nsfw_post(&self, ctx: &Context<'_>, post_id: ID) -> Result<Post> {
+        let user = permissions::require_auth_not_banned(ctx)?;
+        let pool = ctx.data::<DbPool>()?;
+        let conn = &mut get_conn(pool).await?;
+
+        let post_uuid: Uuid = post_id
+            .parse()
+            .map_err(|_| TinyBoardsError::from_message(400, "Invalid post ID"))?;
+
+        let post: DbPost = posts::table
+            .find(post_uuid)
+            .first(conn)
+            .await
+            .map_err(|_| TinyBoardsError::NotFound("Post not found".into()))?;
+
+        require_mod_or_admin(user, pool, post.board_id, ModPerms::Content, Some(AdminPerms::Content))
+            .await?;
+
+        diesel::update(posts::table.find(post_uuid))
+            .set(&PostUpdateForm {
+                is_nsfw: Some(true),
+                ..Default::default()
+            })
+            .execute(conn)
+            .await
+            .map_err(|e| TinyBoardsError::Database(e.to_string()))?;
+
+        diesel::insert_into(moderation_log::table)
+            .values(&ModerationLogInsertForm {
+                moderator_id: user.id,
+                action_type: DbModerationAction::MarkNsfw,
+                target_type: "post".to_string(),
+                target_id: post_uuid,
+                board_id: Some(post.board_id),
+                reason: None,
+                metadata: None,
+                expires_at: None,
+            })
+            .execute(conn)
+            .await
+            .map_err(|e| TinyBoardsError::Database(e.to_string()))?;
+
+        load_post_with_counts(conn, post_uuid)
+            .await
+            .map_err(|e| e.into())
+    }
+
+    /// Unmark a post as NSFW (mod/admin action)
+    pub async fn unmark_nsfw_post(&self, ctx: &Context<'_>, post_id: ID) -> Result<Post> {
+        let user = permissions::require_auth_not_banned(ctx)?;
+        let pool = ctx.data::<DbPool>()?;
+        let conn = &mut get_conn(pool).await?;
+
+        let post_uuid: Uuid = post_id
+            .parse()
+            .map_err(|_| TinyBoardsError::from_message(400, "Invalid post ID"))?;
+
+        let post: DbPost = posts::table
+            .find(post_uuid)
+            .first(conn)
+            .await
+            .map_err(|_| TinyBoardsError::NotFound("Post not found".into()))?;
+
+        require_mod_or_admin(user, pool, post.board_id, ModPerms::Content, Some(AdminPerms::Content))
+            .await?;
+
+        diesel::update(posts::table.find(post_uuid))
+            .set(&PostUpdateForm {
+                is_nsfw: Some(false),
+                ..Default::default()
+            })
+            .execute(conn)
+            .await
+            .map_err(|e| TinyBoardsError::Database(e.to_string()))?;
+
+        diesel::insert_into(moderation_log::table)
+            .values(&ModerationLogInsertForm {
+                moderator_id: user.id,
+                action_type: DbModerationAction::UnmarkNsfw,
+                target_type: "post".to_string(),
+                target_id: post_uuid,
+                board_id: Some(post.board_id),
+                reason: None,
+                metadata: None,
+                expires_at: None,
+            })
+            .execute(conn)
+            .await
+            .map_err(|e| TinyBoardsError::Database(e.to_string()))?;
+
+        load_post_with_counts(conn, post_uuid)
+            .await
+            .map_err(|e| e.into())
+    }
 }

--- a/backend/crates/api/src/queries/moderation/moderation_log.rs
+++ b/backend/crates/api/src/queries/moderation/moderation_log.rs
@@ -69,6 +69,8 @@ fn action_type_str(action: &DbModerationAction) -> &'static str {
         DbModerationAction::PurgePost => "purge_post",
         DbModerationAction::PurgeComment => "purge_comment",
         DbModerationAction::PurgeBoard => "purge_board",
+        DbModerationAction::MarkNsfw => "mark_nsfw",
+        DbModerationAction::UnmarkNsfw => "unmark_nsfw",
     }
 }
 

--- a/backend/crates/api/src/queries/moderation/moderation_stats.rs
+++ b/backend/crates/api/src/queries/moderation/moderation_stats.rs
@@ -83,6 +83,8 @@ fn action_to_str(action: &DbModerationAction) -> &'static str {
         DbModerationAction::PurgePost => "purge_post",
         DbModerationAction::PurgeComment => "purge_comment",
         DbModerationAction::PurgeBoard => "purge_board",
+        DbModerationAction::MarkNsfw => "mark_nsfw",
+        DbModerationAction::UnmarkNsfw => "unmark_nsfw",
     }
 }
 

--- a/backend/crates/db/src/enums.rs
+++ b/backend/crates/db/src/enums.rs
@@ -168,6 +168,8 @@ pg_enum! {
         PurgePost => b"purge_post",
         PurgeComment => b"purge_comment",
         PurgeBoard => b"purge_board",
+        MarkNsfw => b"mark_nsfw",
+        UnmarkNsfw => b"unmark_nsfw",
     }
 }
 

--- a/frontend/components/common/NsfwBlur.vue
+++ b/frontend/components/common/NsfwBlur.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+const props = defineProps<{
+  isNsfw: boolean
+}>()
+
+const revealed = ref(false)
+
+function reveal () {
+  revealed.value = true
+}
+</script>
+
+<template>
+  <div v-if="isNsfw && !revealed" class="relative cursor-pointer overflow-hidden rounded-lg" @click.stop="reveal">
+    <div class="blur-lg pointer-events-none select-none">
+      <slot />
+    </div>
+    <div class="absolute inset-0 flex items-center justify-center bg-black/40 rounded-lg">
+      <span class="px-3 py-1.5 bg-red-600 text-white text-sm font-medium rounded shadow">
+        NSFW &mdash; Click to reveal
+      </span>
+    </div>
+  </div>
+  <slot v-else />
+</template>

--- a/frontend/components/post/PostCard.vue
+++ b/frontend/components/post/PostCard.vue
@@ -124,13 +124,14 @@ const hasLinkPreview = computed(() => {
         </span>
 
         <!-- Compact thumbnail -->
-        <img
-          v-if="post.thumbnailUrl"
-          :src="post.thumbnailUrl"
-          :alt="post.title"
-          class="w-10 h-10 rounded object-cover shrink-0"
-          loading="lazy"
-        />
+        <CommonNsfwBlur v-if="post.thumbnailUrl" :is-nsfw="post.isNSFW" class="shrink-0">
+          <img
+            :src="post.thumbnailUrl"
+            :alt="post.title"
+            class="w-10 h-10 rounded object-cover"
+            loading="lazy"
+          />
+        </CommonNsfwBlur>
 
         <!-- Meta -->
         <NuxtLink
@@ -248,37 +249,40 @@ const hasLinkPreview = computed(() => {
 
           <!-- Video embed (YouTube or direct video) -->
           <ClientOnly>
-            <div v-if="isYouTubeEmbed" class="mt-2 rounded-lg overflow-hidden aspect-video max-w-full sm:max-w-lg">
-              <iframe
-                :src="post.embedVideoUrl!"
-                class="w-full h-full"
-                frameborder="0"
-                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                allowfullscreen
-                loading="lazy"
-              />
-            </div>
-            <div v-else-if="isDirectVideo" class="mt-2 max-w-full sm:max-w-lg">
+            <CommonNsfwBlur v-if="isYouTubeEmbed" :is-nsfw="post.isNSFW" class="mt-2 max-w-full sm:max-w-lg">
+              <div class="rounded-lg overflow-hidden aspect-video">
+                <iframe
+                  :src="post.embedVideoUrl!"
+                  class="w-full h-full"
+                  frameborder="0"
+                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                  allowfullscreen
+                  loading="lazy"
+                />
+              </div>
+            </CommonNsfwBlur>
+            <CommonNsfwBlur v-else-if="isDirectVideo" :is-nsfw="post.isNSFW" class="mt-2 max-w-full sm:max-w-lg">
               <video
                 :src="post.embedVideoUrl!"
                 class="w-full rounded-lg"
                 controls
                 preload="metadata"
               />
-            </div>
+            </CommonNsfwBlur>
           </ClientOnly>
 
           <!-- Thumbnail image (when no video but thumbnail exists) -->
-          <img
-            v-if="!post.embedVideoUrl && post.thumbnailUrl"
-            :src="post.thumbnailUrl"
-            :alt="post.title"
-            class="mt-2 max-w-full sm:max-w-sm max-h-64 rounded-lg object-cover"
-            loading="lazy"
-          />
+          <CommonNsfwBlur v-if="!post.embedVideoUrl && post.thumbnailUrl" :is-nsfw="post.isNSFW" class="mt-2">
+            <img
+              :src="post.thumbnailUrl"
+              :alt="post.title"
+              class="max-w-full sm:max-w-sm max-h-64 rounded-lg object-cover"
+              loading="lazy"
+            />
+          </CommonNsfwBlur>
 
           <!-- Post video (uploaded video file) -->
-          <div v-if="isImageVideo" class="mt-2 max-w-full sm:max-w-lg">
+          <CommonNsfwBlur v-if="isImageVideo" :is-nsfw="post.isNSFW" class="mt-2 max-w-full sm:max-w-lg">
             <video
               :src="post.image!"
               class="w-full rounded-lg"
@@ -286,35 +290,37 @@ const hasLinkPreview = computed(() => {
               preload="metadata"
               :alt="post.altText || post.title"
             />
-          </div>
+          </CommonNsfwBlur>
 
           <!-- Post image -->
-          <img
-            v-if="post.image && !post.thumbnailUrl && !isImageVideo"
-            :src="post.image"
-            :alt="post.altText || post.title"
-            class="mt-2 max-w-full sm:max-w-sm max-h-64 rounded-lg object-cover"
-            loading="lazy"
-          />
+          <CommonNsfwBlur v-if="post.image && !post.thumbnailUrl && !isImageVideo" :is-nsfw="post.isNSFW" class="mt-2">
+            <img
+              :src="post.image"
+              :alt="post.altText || post.title"
+              class="max-w-full sm:max-w-sm max-h-64 rounded-lg object-cover"
+              loading="lazy"
+            />
+          </CommonNsfwBlur>
 
           <!-- Link preview card (for link posts without video) -->
-          <a
-            v-if="hasLinkPreview && post.url"
-            :href="post.url"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="mt-2 block border border-gray-200 rounded-lg overflow-hidden hover:border-gray-300 transition-colors no-underline max-w-full sm:max-w-lg"
-          >
-            <div class="px-3 py-2">
-              <p v-if="post.embedTitle" class="text-sm font-medium text-gray-800 line-clamp-1">
-                {{ post.embedTitle }}
-              </p>
-              <p v-if="post.embedDescription" class="text-xs text-gray-500 line-clamp-2 mt-0.5">
-                {{ post.embedDescription }}
-              </p>
-              <p class="text-xs text-gray-400 mt-1">{{ linkHostname }}</p>
-            </div>
-          </a>
+          <CommonNsfwBlur v-if="hasLinkPreview && post.url" :is-nsfw="post.isNSFW" class="mt-2">
+            <a
+              :href="post.url"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="block border border-gray-200 rounded-lg overflow-hidden hover:border-gray-300 transition-colors no-underline max-w-full sm:max-w-lg"
+            >
+              <div class="px-3 py-2">
+                <p v-if="post.embedTitle" class="text-sm font-medium text-gray-800 line-clamp-1">
+                  {{ post.embedTitle }}
+                </p>
+                <p v-if="post.embedDescription" class="text-xs text-gray-500 line-clamp-2 mt-0.5">
+                  {{ post.embedDescription }}
+                </p>
+                <p class="text-xs text-gray-400 mt-1">{{ linkHostname }}</p>
+              </div>
+            </a>
+          </CommonNsfwBlur>
 
           <!-- Body preview (if text post) -->
           <div

--- a/frontend/components/post/PostDetail.vue
+++ b/frontend/components/post/PostDetail.vue
@@ -20,7 +20,7 @@ const emit = defineEmits<{
 const authStore = useAuthStore()
 const toast = useToast()
 
-const { removePost: doRemovePost, restorePost: doRestorePost, lockPost: doLockPost, unlockPost: doUnlockPost, featurePost: doFeaturePost, distinguishPost: doDistinguishPost } = useModeration()
+const { removePost: doRemovePost, restorePost: doRestorePost, lockPost: doLockPost, unlockPost: doUnlockPost, featurePost: doFeaturePost, distinguishPost: doDistinguishPost, markNsfwPost: doMarkNsfwPost, unmarkNsfwPost: doUnmarkNsfwPost } = useModeration()
 
 const SAVE_MUTATION = `mutation SavePost($postId: ID!) { savePost(postId: $postId) { id isSaved } }`
 const UNSAVE_MUTATION = `mutation UnsavePost($postId: ID!) { unsavePost(postId: $postId) { id isSaved } }`
@@ -117,6 +117,16 @@ async function handleDistinguish (): Promise<void> {
   if (success) emit('post-updated')
 }
 
+async function handleNsfwToggle (): Promise<void> {
+  acting.value = true
+  showMoreMenu.value = false
+  const success = props.post.isNSFW
+    ? await doUnmarkNsfwPost(props.post.id)
+    : await doMarkNsfwPost(props.post.id)
+  acting.value = false
+  if (success) emit('post-updated')
+}
+
 function openRemoveDialog (): void {
   showMoreMenu.value = false
   showRemoveDialog.value = true
@@ -151,37 +161,39 @@ function onClickOutsideMenu (e: Event): void {
         </a>
 
         <!-- Video display (uploaded video file) -->
-        <div v-if="post.image && isImageVideo" class="mt-3">
+        <CommonNsfwBlur v-if="post.image && isImageVideo" :is-nsfw="post.isNSFW" class="mt-3">
           <video
             :src="post.image"
             class="max-w-full max-h-[400px] sm:max-h-[600px] rounded-lg border border-gray-200"
             controls
             preload="metadata"
           />
-        </div>
+        </CommonNsfwBlur>
 
         <!-- Image display -->
-        <div v-if="post.image && !isImageVideo" class="mt-3">
+        <CommonNsfwBlur v-if="post.image && !isImageVideo" :is-nsfw="post.isNSFW" class="mt-3">
           <img
             :src="post.image"
             :alt="post.altText || post.title"
             class="max-w-full max-h-[400px] sm:max-h-[600px] rounded-lg border border-gray-200 object-contain"
           />
-        </div>
+        </CommonNsfwBlur>
 
         <!-- Embed preview -->
-        <div v-if="post.embedTitle || post.embedDescription" class="mt-3 border border-gray-200 rounded-lg p-3 bg-gray-50">
-          <p v-if="post.embedTitle" class="text-sm font-medium text-gray-900">{{ post.embedTitle }}</p>
-          <p v-if="post.embedDescription" class="text-xs text-gray-600 mt-1">{{ post.embedDescription }}</p>
-          <div v-if="post.embedVideoUrl" class="mt-2">
-            <iframe
-              :src="post.embedVideoUrl"
-              class="w-full aspect-video rounded"
-              allowfullscreen
-              loading="lazy"
-            />
+        <CommonNsfwBlur v-if="post.embedTitle || post.embedDescription" :is-nsfw="post.isNSFW" class="mt-3">
+          <div class="border border-gray-200 rounded-lg p-3 bg-gray-50">
+            <p v-if="post.embedTitle" class="text-sm font-medium text-gray-900">{{ post.embedTitle }}</p>
+            <p v-if="post.embedDescription" class="text-xs text-gray-600 mt-1">{{ post.embedDescription }}</p>
+            <div v-if="post.embedVideoUrl" class="mt-2">
+              <iframe
+                :src="post.embedVideoUrl"
+                class="w-full aspect-video rounded"
+                allowfullscreen
+                loading="lazy"
+              />
+            </div>
           </div>
-        </div>
+        </CommonNsfwBlur>
 
         <!-- Meta -->
         <div class="flex items-center gap-1.5 sm:gap-1 mt-2 text-xs text-gray-500 flex-wrap">
@@ -330,6 +342,20 @@ function onClickOutsideMenu (e: Event): void {
                       <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
                     </svg>
                     {{ post.isFeaturedBoard ? 'Unpin post' : 'Pin post' }}
+                  </button>
+
+                  <!-- NSFW Toggle -->
+                  <button
+                    class="w-full flex items-center gap-2 px-3 py-2 text-sm transition-colors"
+                    :class="post.isNSFW ? 'text-red-700 hover:bg-red-50' : 'text-gray-700 hover:bg-gray-50'"
+                    :disabled="acting"
+                    @click="handleNsfwToggle"
+                  >
+                    <svg class="w-4 h-4" :class="post.isNSFW ? 'text-red-500' : 'text-gray-400'" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path v-if="post.isNSFW" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.878 9.878L3 3m6.878 6.878L21 21" />
+                      <path v-else stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4.5c-.77-.833-2.694-.833-3.464 0L3.34 16.5c-.77.833.192 2.5 1.732 2.5z" />
+                    </svg>
+                    {{ post.isNSFW ? 'Unmark NSFW' : 'Mark NSFW' }}
                   </button>
 
                   <!-- Distinguish (own posts only) -->

--- a/frontend/components/post/PostModActions.vue
+++ b/frontend/components/post/PostModActions.vue
@@ -12,7 +12,7 @@ const emit = defineEmits<{
   updated: []
 }>()
 
-const { lockPost, unlockPost, featurePost, removePost, restorePost, distinguishPost } = useModeration()
+const { lockPost, unlockPost, featurePost, removePost, restorePost, distinguishPost, markNsfwPost, unmarkNsfwPost } = useModeration()
 
 const authStore = useAuthStore()
 const showRemoveDialog = ref(false)
@@ -24,6 +24,15 @@ const isOwnPost = computed(() => authStore.user?.id === props.post.creatorId)
 async function handleDistinguish (): Promise<void> {
   acting.value = true
   const success = await distinguishPost(props.post.id)
+  acting.value = false
+  if (success) emit('updated')
+}
+
+async function handleNsfwToggle (): Promise<void> {
+  acting.value = true
+  const success = props.post.isNSFW
+    ? await unmarkNsfwPost(props.post.id)
+    : await markNsfwPost(props.post.id)
   acting.value = false
   if (success) emit('updated')
 }
@@ -101,6 +110,20 @@ async function handleRestore (): Promise<void> {
         <path d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
       </svg>
       {{ post.distinguishedAs ? 'Undistinguish' : 'Distinguish' }}
+    </button>
+
+    <!-- NSFW Toggle -->
+    <button
+      class="inline-flex items-center gap-1 px-2 py-1 rounded hover:bg-gray-100"
+      :class="post.isNSFW ? 'text-red-600 hover:text-red-700' : 'text-gray-500 hover:text-gray-700'"
+      :disabled="acting"
+      @click="handleNsfwToggle"
+    >
+      <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path v-if="post.isNSFW" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.878 9.878L3 3m6.878 6.878L21 21" />
+        <path v-else stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4.5c-.77-.833-2.694-.833-3.464 0L3.34 16.5c-.77.833.192 2.5 1.732 2.5z" />
+      </svg>
+      {{ post.isNSFW ? 'Unmark NSFW' : 'Mark NSFW' }}
     </button>
 
     <!-- Remove / Restore -->

--- a/frontend/composables/useModeration.ts
+++ b/frontend/composables/useModeration.ts
@@ -110,6 +110,18 @@ const DISTINGUISH_COMMENT_MUTATION = `
   }
 `
 
+const MARK_NSFW_POST_MUTATION = `
+  mutation MarkNsfwPost($postId: ID!) {
+    markNsfwPost(postId: $postId) { id isNSFW }
+  }
+`
+
+const UNMARK_NSFW_POST_MUTATION = `
+  mutation UnmarkNsfwPost($postId: ID!) {
+    unmarkNsfwPost(postId: $postId) { id isNSFW }
+  }
+`
+
 export { type PostReportView, type CommentReportView }
 
 export function useModeration () {
@@ -236,6 +248,24 @@ export function useModeration () {
     return false
   }
 
+  async function markNsfwPost (postId: string): Promise<boolean> {
+    const toast = useToast()
+    const { execute: exec, error: mutError } = useGraphQL()
+    const result = await exec(MARK_NSFW_POST_MUTATION, { variables: { postId } })
+    if (result) { toast.success('Post marked as NSFW'); return true }
+    toast.error(mutError.value?.message ?? 'Failed to mark post as NSFW')
+    return false
+  }
+
+  async function unmarkNsfwPost (postId: string): Promise<boolean> {
+    const toast = useToast()
+    const { execute: exec, error: mutError } = useGraphQL()
+    const result = await exec(UNMARK_NSFW_POST_MUTATION, { variables: { postId } })
+    if (result) { toast.success('NSFW mark removed'); return true }
+    toast.error(mutError.value?.message ?? 'Failed to remove NSFW mark')
+    return false
+  }
+
   async function distinguishComment (commentId: string): Promise<boolean> {
     const toast = useToast()
     const { execute: exec, error: mutError } = useGraphQL()
@@ -263,5 +293,7 @@ export function useModeration () {
     dismissReport,
     distinguishPost,
     distinguishComment,
+    markNsfwPost,
+    unmarkNsfwPost,
   }
 }

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -166,6 +166,8 @@ type Mutation {
   removePost(postId: ID!, reason: String): Post!
   restorePost(postId: ID!): Post!
   distinguishPost(postId: ID!): Post!
+  markNsfwPost(postId: ID!): Post!
+  unmarkNsfwPost(postId: ID!): Post!
 
   # Comments
   createComment(postId: ID!, body: String!, parentId: ID): Comment!

--- a/migrations/2026-04-10-000024_nsfw_moderation_action/down.sql
+++ b/migrations/2026-04-10-000024_nsfw_moderation_action/down.sql
@@ -1,0 +1,1 @@
+-- PostgreSQL does not support removing enum values. No-op.

--- a/migrations/2026-04-10-000024_nsfw_moderation_action/up.sql
+++ b/migrations/2026-04-10-000024_nsfw_moderation_action/up.sql
@@ -1,0 +1,2 @@
+ALTER TYPE moderation_action ADD VALUE 'mark_nsfw';
+ALTER TYPE moderation_action ADD VALUE 'unmark_nsfw';

--- a/schema.graphql
+++ b/schema.graphql
@@ -166,6 +166,8 @@ type Mutation {
   removePost(postId: ID!, reason: String): Post!
   restorePost(postId: ID!): Post!
   distinguishPost(postId: ID!): Post!
+  markNsfwPost(postId: ID!): Post!
+  unmarkNsfwPost(postId: ID!): Post!
 
   # Comments
   createComment(postId: ID!, body: String!, parentId: ID): Comment!


### PR DESCRIPTION
…ntent

Add markNsfwPost/unmarkNsfwPost GraphQL mutations so moderators and admins can flag or unflag posts as NSFW after creation. Actions are logged to the moderation log.

NSFW posts now blur all media (images, thumbnails, videos, embeds) with a click-to-reveal overlay in both PostCard and PostDetail views using a reusable NsfwBlur wrapper component.

Changes:
- Migration 000024: add mark_nsfw/unmark_nsfw to moderation_action enum
- Backend: new mutations on PostModeration, updated match arms in moderation_log and moderation_stats queries
- Frontend: useModeration composable gains markNsfwPost/unmarkNsfwPost, PostDetail mod menu and PostModActions get NSFW toggle button, NsfwBlur component wraps all media elements in PostCard and PostDetail