### PR TITLE
feat(frontend): remove welcome hero, revamp sidebars, fix board emoji…

### DIFF
--- a/frontend/components/comment/CommentForm.vue
+++ b/frontend/components/comment/CommentForm.vue
@@ -4,6 +4,7 @@ import { useAuthStore } from '~/stores/auth'
 
 defineProps<{
   placeholder?: string
+  boardId?: string
 }>()
 
 const emit = defineEmits<{
@@ -24,6 +25,7 @@ function handleSubmit (): void {
   <div v-if="authStore.isLoggedIn" class="mt-4">
     <EditorMarkdownEditor
       v-model="body"
+      :board-id="boardId"
       :placeholder="placeholder ?? 'Write a comment...'"
       min-height="80px"
     />

--- a/frontend/components/comment/CommentItem.vue
+++ b/frontend/components/comment/CommentItem.vue
@@ -12,6 +12,7 @@ const props = defineProps<{
   postId: string
   depth?: number
   isModerator?: boolean
+  boardId?: string
 }>()
 
 const emit = defineEmits<{
@@ -105,6 +106,7 @@ function submitReply (): void {
       <div v-if="showReply && authStore.isLoggedIn" class="mt-2">
         <EditorMarkdownEditor
           v-model="replyBody"
+          :board-id="boardId"
           placeholder="Write a reply..."
           min-height="80px"
         />
@@ -127,6 +129,7 @@ function submitReply (): void {
           :post-id="postId"
           :depth="currentDepth + 1"
           :is-moderator="isModerator"
+          :board-id="boardId"
           @reply="(parentId, body) => emit('reply', parentId, body)"
         />
       </div>

--- a/frontend/components/comment/CommentTree.vue
+++ b/frontend/components/comment/CommentTree.vue
@@ -7,6 +7,7 @@ const props = defineProps<{
   postId: string
   loading: boolean
   isModerator?: boolean
+  boardId?: string
 }>()
 
 const emit = defineEmits<{
@@ -52,6 +53,7 @@ const rootComments = computed(() => {
         :comment="comment"
         :post-id="postId"
         :is-moderator="isModerator"
+        :board-id="boardId"
         @reply="(parentId, body) => emit('reply', parentId, body)"
       />
     </div>

--- a/frontend/components/editor/MarkdownEditor.vue
+++ b/frontend/components/editor/MarkdownEditor.vue
@@ -7,6 +7,7 @@ const props = defineProps<{
   modelValue: string
   placeholder?: string
   minHeight?: string
+  boardId?: string
 }>()
 
 const emit = defineEmits<{
@@ -17,7 +18,7 @@ const content = ref(props.modelValue)
 const textareaRef = ref<HTMLTextAreaElement | null>(null)
 const showPreview = ref(false)
 
-const autocomplete = useEditorAutocomplete()
+const autocomplete = useEditorAutocomplete(props.boardId)
 
 watch(content, (val) => {
   emit('update:modelValue', val)

--- a/frontend/components/editor/RichTextEditor.vue
+++ b/frontend/components/editor/RichTextEditor.vue
@@ -31,6 +31,7 @@ const props = defineProps<{
   modelValue: string
   placeholder?: string
   minHeight?: string
+  boardId?: string
 }>()
 
 const emit = defineEmits<{
@@ -38,7 +39,7 @@ const emit = defineEmits<{
 }>()
 
 const { uploadFile: doUpload, uploading } = useFileUpload()
-const autocomplete = useEditorAutocomplete()
+const autocomplete = useEditorAutocomplete(props.boardId)
 
 // Dropdowns
 const showTextColor = ref(false)
@@ -430,7 +431,7 @@ defineExpose({ insertQuoteBlock, clearContent })
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10" /><path d="M8 14s1.5 2 4 2 4-2 4-2" /><line x1="9" y1="9" x2="9.01" y2="9" /><line x1="15" y1="9" x2="15.01" y2="9" /></svg>
         </button>
         <div v-if="showEmojiPicker" class="dropdown-panel dropdown-panel-emoji">
-          <EditorEmojiPicker @select="handleEmojiSelect" @select-custom="handleCustomEmojiSelect" />
+          <EditorEmojiPicker :board-id="boardId" @select="handleEmojiSelect" @select-custom="handleCustomEmojiSelect" />
         </div>
       </div>
 

--- a/frontend/components/post/PostForm.vue
+++ b/frontend/components/post/PostForm.vue
@@ -3,6 +3,7 @@ import { ref } from 'vue'
 
 const props = defineProps<{
   boardName?: string
+  boardId?: string
   initialTitle?: string
   initialBody?: string
   initialUrl?: string
@@ -186,6 +187,7 @@ function handleSubmit (): void {
       </label>
       <EditorRichTextEditor
         v-model="body"
+        :board-id="boardId"
         :placeholder="activeTab === 'link' ? 'Add a description...' : activeTab === 'media' ? 'Add a caption...' : 'Write your post...'"
         min-height="150px"
       />

--- a/frontend/components/sidebar/AllSidebar.vue
+++ b/frontend/components/sidebar/AllSidebar.vue
@@ -1,11 +1,9 @@
 <script setup lang="ts">
 import { useAuthStore } from '~/stores/auth'
-import { useSiteStore } from '~/stores/site'
 import { useGraphQL } from '~/composables/useGraphQL'
 import type { Board } from '~/types/generated'
 
 const authStore = useAuthStore()
-const siteStore = useSiteStore()
 
 const TRENDING_BOARDS_QUERY = `
   query TrendingBoards($limit: Int, $sort: SortType) {
@@ -76,22 +74,6 @@ function formatCount (n: number): string {
       New Post
     </NuxtLink>
 
-    <!-- All posts info card -->
-    <div class="bg-white rounded-lg border border-gray-200 overflow-hidden">
-      <div class="h-16 bg-gradient-to-br from-blue-500 to-indigo-600" />
-      <div class="px-4 py-3 -mt-4">
-        <div class="w-10 h-10 rounded-lg bg-white shadow-sm border border-gray-100 flex items-center justify-center mb-2">
-          <svg class="w-5 h-5 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-          </svg>
-        </div>
-        <h3 class="font-semibold text-sm text-gray-900">All Posts</h3>
-        <p class="text-xs text-gray-500 mt-1 leading-relaxed">
-          Everything happening across {{ siteStore.name }}. Posts from every board in one feed.
-        </p>
-      </div>
-    </div>
-
     <!-- Site Stats -->
     <div v-if="siteStats" class="bg-white rounded-lg border border-gray-200 p-3">
       <h4 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">
@@ -144,39 +126,6 @@ function formatCount (n: number): string {
               <span class="inline-block w-1.5 h-1.5 rounded-full bg-green-400" />
               {{ board.usersActiveDay ?? 0 }}
             </div>
-          </NuxtLink>
-        </li>
-      </ul>
-    </div>
-
-    <!-- Quick links -->
-    <div>
-      <h4 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2 px-1">
-        Explore
-      </h4>
-      <ul class="space-y-0.5">
-        <li>
-          <NuxtLink to="/boards" class="flex items-center gap-2.5 px-2 py-1.5 text-sm text-gray-600 rounded-md hover:bg-gray-100 hover:text-gray-900 no-underline transition-colors">
-            <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z" />
-            </svg>
-            Browse Boards
-          </NuxtLink>
-        </li>
-        <li>
-          <NuxtLink to="/home" class="flex items-center gap-2.5 px-2 py-1.5 text-sm text-gray-600 rounded-md hover:bg-gray-100 hover:text-gray-900 no-underline transition-colors">
-            <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
-            </svg>
-            Home Feed
-          </NuxtLink>
-        </li>
-        <li>
-          <NuxtLink to="/members" class="flex items-center gap-2.5 px-2 py-1.5 text-sm text-gray-600 rounded-md hover:bg-gray-100 hover:text-gray-900 no-underline transition-colors">
-            <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
-            </svg>
-            Members
           </NuxtLink>
         </li>
       </ul>

--- a/frontend/components/sidebar/BoardsDirectorySidebar.vue
+++ b/frontend/components/sidebar/BoardsDirectorySidebar.vue
@@ -1,29 +1,42 @@
 <script setup lang="ts">
 import { useAuthStore } from '~/stores/auth'
 import { useSiteStore } from '~/stores/site'
+import { useGraphQL } from '~/composables/useGraphQL'
+import type { Board } from '~/types/generated'
 
 const authStore = useAuthStore()
 const siteStore = useSiteStore()
+
+const TRENDING_BOARDS_QUERY = `
+  query TrendingBoards($limit: Int, $sort: SortType) {
+    listBoards(limit: $limit, sort: $sort) {
+      id
+      name
+      title
+      icon
+      subscribers
+      usersActiveDay
+    }
+  }
+`
+
+const { execute } = useGraphQL<{ listBoards: Board[] }>()
+const trendingBoards = ref<Board[]>([])
+
+async function fetchTrending (): Promise<void> {
+  const result = await execute(TRENDING_BOARDS_QUERY, {
+    variables: { limit: 5, sort: 'active' },
+  })
+  if (result?.listBoards) {
+    trendingBoards.value = result.listBoards
+  }
+}
+
+await fetchTrending()
 </script>
 
 <template>
   <div class="space-y-5">
-    <!-- Boards directory info -->
-    <div class="bg-white rounded-lg border border-gray-200 overflow-hidden">
-      <div class="h-16 bg-gradient-to-br from-emerald-500 to-teal-600" />
-      <div class="px-4 py-3 -mt-4">
-        <div class="w-10 h-10 rounded-lg bg-white shadow-sm border border-gray-100 flex items-center justify-center mb-2">
-          <svg class="w-5 h-5 text-emerald-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z" />
-          </svg>
-        </div>
-        <h3 class="font-semibold text-sm text-gray-900">Board Directory</h3>
-        <p class="text-xs text-gray-500 mt-1 leading-relaxed">
-          Discover communities on {{ siteStore.name }}. Find boards that match your interests.
-        </p>
-      </div>
-    </div>
-
     <!-- Your boards -->
     <div v-if="authStore.isLoggedIn && authStore.subscribedBoards?.length > 0">
       <h4 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2 px-1">
@@ -44,6 +57,32 @@ const siteStore = useSiteStore()
           </NuxtLink>
         </li>
       </ul>
+    </div>
+
+    <!-- Trending boards -->
+    <div v-if="trendingBoards.length > 0">
+      <h4 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2 px-1">
+        Trending
+      </h4>
+      <ol class="space-y-0.5">
+        <li v-for="(board, i) in trendingBoards" :key="board.id">
+          <NuxtLink
+            :to="`/b/${board.name}`"
+            class="flex items-center gap-2.5 px-2 py-1.5 rounded-md hover:bg-gray-100 no-underline transition-colors group"
+          >
+            <span class="text-[10px] font-bold text-gray-300 w-3 text-right">{{ i + 1 }}</span>
+            <CommonAvatar
+              :src="board.icon ?? undefined"
+              :name="board.name"
+              size="xs"
+            />
+            <div class="flex-1 min-w-0">
+              <span class="text-sm text-gray-700 group-hover:text-gray-900 truncate block">{{ board.title }}</span>
+              <span class="text-[10px] text-gray-400">{{ board.subscribers }} members</span>
+            </div>
+          </NuxtLink>
+        </li>
+      </ol>
     </div>
 
     <!-- Create board CTA -->

--- a/frontend/components/sidebar/HomeSidebar.vue
+++ b/frontend/components/sidebar/HomeSidebar.vue
@@ -64,11 +64,10 @@ function formatCount (n: number): string {
 
 <template>
   <div class="space-y-4">
-    <!-- Site welcome card -->
-    <div class="bg-white rounded-lg border border-gray-200 overflow-hidden">
-      <div class="h-16 bg-gradient-to-br from-primary to-primary-hover" />
-      <div class="px-4 py-3 -mt-4">
-        <div class="w-10 h-10 rounded-lg bg-white shadow-sm border border-gray-100 flex items-center justify-center mb-2">
+    <!-- Site identity card -->
+    <div class="bg-white rounded-lg border border-gray-200 p-4">
+      <div class="flex items-center gap-3 mb-2">
+        <div class="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center shrink-0">
           <img
             v-if="siteStore.icon"
             :src="siteStore.icon"
@@ -79,10 +78,18 @@ function formatCount (n: number): string {
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
           </svg>
         </div>
-        <h3 class="font-semibold text-sm text-gray-900">Home</h3>
-        <p class="text-xs text-gray-500 mt-1 leading-relaxed">
-          Your personal front page. Posts from boards you've joined appear here.
-        </p>
+        <h3 class="font-semibold text-sm text-gray-900">{{ siteStore.name || 'TinyBoards' }}</h3>
+      </div>
+      <p v-if="siteStore.description" class="text-xs text-gray-500 leading-relaxed">
+        {{ siteStore.description }}
+      </p>
+      <div v-if="!authStore.isLoggedIn" class="flex items-center gap-2 mt-3">
+        <NuxtLink to="/register" class="button button-sm primary no-underline flex-1 text-center">
+          Sign Up
+        </NuxtLink>
+        <NuxtLink to="/login" class="button button-sm white no-underline flex-1 text-center">
+          Log In
+        </NuxtLink>
       </div>
     </div>
 
@@ -169,39 +176,6 @@ function formatCount (n: number): string {
           </NuxtLink>
         </li>
       </ol>
-    </div>
-
-    <!-- Quick nav -->
-    <div>
-      <h4 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2 px-1">
-        Explore
-      </h4>
-      <ul class="space-y-0.5">
-        <li>
-          <NuxtLink to="/boards" class="flex items-center gap-2.5 px-2 py-1.5 text-sm text-gray-600 rounded-md hover:bg-gray-100 hover:text-gray-900 no-underline transition-colors">
-            <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z" />
-            </svg>
-            All Boards
-          </NuxtLink>
-        </li>
-        <li>
-          <NuxtLink to="/all" class="flex items-center gap-2.5 px-2 py-1.5 text-sm text-gray-600 rounded-md hover:bg-gray-100 hover:text-gray-900 no-underline transition-colors">
-            <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-            </svg>
-            All Posts
-          </NuxtLink>
-        </li>
-        <li>
-          <NuxtLink to="/members" class="flex items-center gap-2.5 px-2 py-1.5 text-sm text-gray-600 rounded-md hover:bg-gray-100 hover:text-gray-900 no-underline transition-colors">
-            <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
-            </svg>
-            Members
-          </NuxtLink>
-        </li>
-      </ul>
     </div>
 
     <!-- Footer links -->

--- a/frontend/components/sidebar/MembersSidebar.vue
+++ b/frontend/components/sidebar/MembersSidebar.vue
@@ -1,29 +1,11 @@
 <script setup lang="ts">
-import { useSiteStore } from '~/stores/site'
 import { useAuthStore } from '~/stores/auth'
 
-const siteStore = useSiteStore()
 const authStore = useAuthStore()
 </script>
 
 <template>
   <div class="space-y-5">
-    <!-- Members info -->
-    <div class="bg-white rounded-lg border border-gray-200 overflow-hidden">
-      <div class="h-16 bg-gradient-to-br from-cyan-500 to-blue-600" />
-      <div class="px-4 py-3 -mt-4">
-        <div class="w-10 h-10 rounded-lg bg-white shadow-sm border border-gray-100 flex items-center justify-center mb-2">
-          <svg class="w-5 h-5 text-cyan-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
-          </svg>
-        </div>
-        <h3 class="font-semibold text-sm text-gray-900">Community</h3>
-        <p class="text-xs text-gray-500 mt-1 leading-relaxed">
-          Members of {{ siteStore.name }}. Search to find people and view their profiles.
-        </p>
-      </div>
-    </div>
-
     <!-- Your boards for context -->
     <div v-if="authStore.isLoggedIn && authStore.subscribedBoards?.length > 0">
       <h4 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2 px-1">

--- a/frontend/components/sidebar/SearchSidebar.vue
+++ b/frontend/components/sidebar/SearchSidebar.vue
@@ -1,27 +1,5 @@
-<script setup lang="ts">
-import { useSiteStore } from '~/stores/site'
-
-const siteStore = useSiteStore()
-</script>
-
 <template>
   <div class="space-y-5">
-    <!-- Search tips -->
-    <div class="bg-white rounded-lg border border-gray-200 overflow-hidden">
-      <div class="h-16 bg-gradient-to-br from-amber-400 to-orange-500" />
-      <div class="px-4 py-3 -mt-4">
-        <div class="w-10 h-10 rounded-lg bg-white shadow-sm border border-gray-100 flex items-center justify-center mb-2">
-          <svg class="w-5 h-5 text-amber-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-          </svg>
-        </div>
-        <h3 class="font-semibold text-sm text-gray-900">Search {{ siteStore.name }}</h3>
-        <p class="text-xs text-gray-500 mt-1 leading-relaxed">
-          Find posts, comments, users, and boards across the platform.
-        </p>
-      </div>
-    </div>
-
     <!-- Search tips card -->
     <div class="bg-white rounded-lg border border-gray-200 p-4">
       <h4 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">

--- a/frontend/components/thread/ThreadCommentForm.vue
+++ b/frontend/components/thread/ThreadCommentForm.vue
@@ -10,6 +10,7 @@ interface QuotedPost {
 
 defineProps<{
   placeholder?: string
+  boardId?: string
 }>()
 
 const emit = defineEmits<{
@@ -113,6 +114,7 @@ defineExpose({ addQuote })
     <EditorRichTextEditor
       ref="editorRef"
       v-model="body"
+      :board-id="boardId"
       :placeholder="placeholder ?? 'Write your reply...'"
       min-height="150px"
     />

--- a/frontend/composables/useEditorAutocomplete.ts
+++ b/frontend/composables/useEditorAutocomplete.ts
@@ -32,7 +32,7 @@ interface CaretCoords {
   height: number
 }
 
-export function useEditorAutocomplete () {
+export function useEditorAutocomplete (explicitBoardId?: string) {
   const state = ref<AutocompleteState>({
     active: false,
     type: null,
@@ -50,16 +50,46 @@ export function useEditorAutocomplete () {
   const customEmoji = useEmoji()
   const currentBoard = useState<Board | null>('current-board', () => null)
 
-  // Fetch custom emojis once on init (includes board-scoped emojis when in a board context)
   let customEmojisFetched = false
 
   function ensureCustomEmojis (): void {
     if (!customEmojisFetched) {
       customEmojisFetched = true
-      const boardId = currentBoard.value?.id
+      const boardId = explicitBoardId ?? currentBoard.value?.id
       customEmoji.fetchAllAvailableEmojis(boardId)
     }
   }
+
+  function buildEmojiSuggestions (query: string): AutocompleteSuggestion[] {
+    const unicode = searchUnicodeEmojis(query, 6)
+    const custom = customEmoji.emojis.value
+      .filter(e => e.shortcode.includes(query.toLowerCase()))
+      .slice(0, 4)
+
+    return [
+      ...unicode.map(e => ({
+        type: 'emoji' as TriggerType,
+        label: `:${e.shortcode}:`,
+        value: e.emoji,
+        icon: e.emoji,
+      })),
+      ...custom.map(e => ({
+        type: 'emoji' as TriggerType,
+        label: `:${e.shortcode}:`,
+        value: e.shortcode,
+        icon: e.imageUrl,
+        secondary: 'custom',
+      })),
+    ]
+  }
+
+  // Rebuild emoji suggestions when async fetch completes
+  watch(customEmoji.emojis, () => {
+    if (state.value.active && state.value.type === 'emoji') {
+      suggestions.value = buildEmojiSuggestions(state.value.query)
+      selectedIndex.value = 0
+    }
+  })
 
   // Watch user autocomplete results
   watch(userAutocomplete.suggestions, (users) => {
@@ -135,27 +165,7 @@ export function useEditorAutocomplete () {
     // Trigger search based on type
     if (type === 'emoji') {
       ensureCustomEmojis()
-      // Combine unicode and custom emoji results
-      const unicode = searchUnicodeEmojis(query, 6)
-      const custom = customEmoji.emojis.value
-        .filter(e => e.shortcode.includes(query.toLowerCase()))
-        .slice(0, 4)
-
-      suggestions.value = [
-        ...unicode.map(e => ({
-          type: 'emoji' as TriggerType,
-          label: `:${e.shortcode}:`,
-          value: e.emoji,
-          icon: e.emoji,
-        })),
-        ...custom.map(e => ({
-          type: 'emoji' as TriggerType,
-          label: `:${e.shortcode}:`,
-          value: e.shortcode,
-          icon: e.imageUrl,
-          secondary: 'custom',
-        })),
-      ]
+      suggestions.value = buildEmojiSuggestions(query)
       selectedIndex.value = 0
     } else if (type === 'user') {
       userAutocomplete.search(query)

--- a/frontend/pages/b/[board]/[id]/[[slug]].vue
+++ b/frontend/pages/b/[board]/[id]/[[slug]].vue
@@ -234,6 +234,7 @@ function handleQuoteOP (author: string, body: string): void {
         <div id="thread-reply-form" class="mt-6">
           <ThreadCommentForm
             ref="commentFormRef"
+            :board-id="post?.board?.id"
             @submit="handleTopLevelComment"
           />
         </div>
@@ -244,7 +245,7 @@ function handleQuoteOP (author: string, body: string): void {
         <PostDetail :post="post" :is-moderator="isModerator" @post-updated="fetchPost" />
 
         <div class="mt-4">
-          <CommentForm @submit="handleTopLevelComment" />
+          <CommentForm :board-id="post?.board?.id" @submit="handleTopLevelComment" />
         </div>
 
         <div class="mt-6">
@@ -254,6 +255,7 @@ function handleQuoteOP (author: string, body: string): void {
             :post-id="postId"
             :loading="commentsLoading"
             :is-moderator="isModerator"
+            :board-id="post?.board?.id"
             @reply="handleReply"
           />
         </div>

--- a/frontend/pages/b/[board]/submit.vue
+++ b/frontend/pages/b/[board]/submit.vue
@@ -112,6 +112,7 @@ async function handleSubmit (data: { title: string; body: string; url: string; f
         <CommonErrorDisplay v-if="uploadError" :message="uploadError.message" class="mb-4" />
         <PostForm
           :board-name="boardName"
+          :board-id="board?.id"
           :submit-label="loading || fileUploading ? 'Posting...' : (board?.mode === 'forum' ? 'Start Discussion' : 'Create Post')"
           @submit="handleSubmit"
         />

--- a/frontend/pages/b/[board]/threads/create.vue
+++ b/frontend/pages/b/[board]/threads/create.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
 import { useGraphQL } from '~/composables/useGraphQL'
+import { useBoard } from '~/composables/useBoard'
 import type { Post } from '~/types/generated'
 
 definePageMeta({ middleware: 'guards' })
 
 const route = useRoute()
 const boardName = route.params.board as string
+const { board: currentBoard } = useBoard()
 
 useHead({ title: `New Thread - ${boardName}` })
 
@@ -89,6 +91,7 @@ async function handleSubmit (): Promise<void> {
           <label class="block text-sm font-medium text-gray-700 mb-1">Opening Post</label>
           <EditorRichTextEditor
             v-model="body"
+            :board-id="currentBoard?.id"
             placeholder="Write the opening post for your thread..."
             min-height="200px"
           />

--- a/frontend/pages/home/[[sort]].vue
+++ b/frontend/pages/home/[[sort]].vue
@@ -103,41 +103,6 @@ async function switchTab (tab: 'feed' | 'threads'): Promise<void> {
 
 <template>
   <div>
-    <!-- Welcome banner for anonymous users -->
-    <div v-if="!authStore.isLoggedIn" class="pt-4">
-      <div class="bg-white rounded-lg border border-gray-200 overflow-hidden">
-        <div class="h-24 bg-gradient-to-br from-primary to-primary-hover" />
-        <div class="px-6 py-4 -mt-6">
-          <div class="w-12 h-12 rounded-xl bg-white shadow-md flex items-center justify-center border border-gray-100 mb-3">
-            <img
-              v-if="siteStore.icon"
-              :src="siteStore.icon"
-              class="w-8 h-8"
-              :alt="siteStore.name"
-            >
-            <svg v-else class="w-7 h-7 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M3.75 21h16.5M4.5 3h15M5.25 3v18m13.5-18v18M9 6.75h1.5m-1.5 3h1.5m-1.5 3h1.5m3-6H15m-1.5 3H15m-1.5 3H15M9 21v-3.375c0-.621.504-1.125 1.125-1.125h3.75c.621 0 1.125.504 1.125 1.125V21" />
-            </svg>
-          </div>
-          <h1 class="text-xl font-bold text-gray-900 mb-1">
-            Welcome to {{ siteStore.name || 'TinyBoards' }}
-          </h1>
-          <p class="text-sm text-gray-600 mb-3 max-w-lg">
-            A community-driven platform for sharing ideas, discussions, and content.
-            Join the conversation or browse what others are talking about.
-          </p>
-          <div class="flex items-center gap-2">
-            <NuxtLink to="/register" class="button button-sm primary no-underline">
-              Create Account
-            </NuxtLink>
-            <NuxtLink to="/boards" class="button button-sm white no-underline">
-              Browse Boards
-            </NuxtLink>
-          </div>
-        </div>
-      </div>
-    </div>
-
     <!-- Tab bar (only when user has both feed and forum boards) -->
     <div v-if="showTabs" class="pt-4">
       <div class="flex gap-1 bg-white rounded-lg border border-gray-200 p-1">

--- a/frontend/pages/submit.vue
+++ b/frontend/pages/submit.vue
@@ -273,6 +273,7 @@ async function handleSubmit (data: { title: string; body: string; url: string; f
 
     <PostForm
       :board-name="boardName"
+      :board-id="boardId ?? undefined"
       :submit-label="loading || fileUploading ? 'Submitting...' : 'Submit'"
       @submit="handleSubmit"
     />


### PR DESCRIPTION
… picker

Remove the large welcome hero banner from /home for logged-out users. Replace generic gradient info cards in all sidebars with useful content: HomeSidebar now shows site identity (name, icon, description) with sign up/log in CTAs for anonymous users. Remove redundant Explore quick-links from Home and All sidebars. Add trending boards to the Boards Directory sidebar.

Fix board-specific emojis not appearing in emoji picker and autocomplete: thread boardId prop through RichTextEditor, MarkdownEditor, PostForm, CommentForm, CommentItem, CommentTree, and ThreadCommentForm. Fix race condition in useEditorAutocomplete where async emoji fetch completed after suggestions were already built by adding a watcher that rebuilds emoji suggestions when the fetch resolves.