### PR TITLE
feat(frontend): tighten NSFW overlay sizing, drop label, blur text bo…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -475,4 +475,5 @@ infallible `unwrap()` on date/time values.
 - **Deprecated routes**: `/b/[board]/feed/` and `/b/[board]/threads/` now 301 redirect to `/b/[board]`.
 
 ### 2026-04-26 — NSFW Overlay Polish
-- Replaced the loud red "NSFW – Click to reveal" button in `components/common/NsfwBlur.vue` with a subtle eye-off icon and small "NSFW" label inside a soft pill-shaped backdrop. Content remains blurred and click-to-reveal; tooltip carries the reveal hint.
+- Replaced the loud red "NSFW – Click to reveal" button in `components/common/NsfwBlur.vue` with a subtle eye-off icon. Content remains blurred and click-to-reveal; tooltip carries the reveal hint.
+- NsfwBlur wrapper now sizes to its slot content by default (`inline-block`) so the icon overlays the actual media rather than empty space beside it. Added a `fluid` prop for slots whose children use `w-full` (videos, iframes, link previews, body text) — those keep the block-level full-width behavior. Updated `PostCard.vue` and `PostDetail.vue` accordingly. Body preview text on NSFW text posts is now blurred too.

--- a/frontend/components/common/NsfwBlur.vue
+++ b/frontend/components/common/NsfwBlur.vue
@@ -1,7 +1,14 @@
 <script setup lang="ts">
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   isNsfw: boolean
-}>()
+  // For media that has no intrinsic width (videos, iframes, link previews
+  // with `w-full` children), pass `fluid` so the wrapper stays block-level
+  // and lets the slot fill it. Default sizes the wrapper to its content so
+  // the icon overlays the actual media instead of empty space beside it.
+  fluid?: boolean
+}>(), {
+  fluid: false
+})
 
 const revealed = ref(false)
 
@@ -13,7 +20,8 @@ function reveal () {
 <template>
   <div
     v-if="isNsfw && !revealed"
-    class="relative cursor-pointer overflow-hidden rounded-lg group"
+    class="relative cursor-pointer overflow-hidden rounded-lg group max-w-full"
+    :class="fluid ? 'block' : 'inline-block align-top'"
     title="NSFW – click to reveal"
     @click.stop="reveal"
   >
@@ -21,7 +29,7 @@ function reveal () {
       <slot />
     </div>
     <div class="absolute inset-0 flex items-center justify-center">
-      <div class="flex flex-col items-center gap-1 px-3 py-2 rounded-full bg-black/30 backdrop-blur-sm text-white/90 transition-opacity group-hover:opacity-100 opacity-90">
+      <div class="flex items-center justify-center w-10 h-10 rounded-full bg-black/30 backdrop-blur-sm text-white/90 transition-opacity group-hover:opacity-100 opacity-90">
         <svg
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 24 24"
@@ -30,7 +38,7 @@ function reveal () {
           stroke-width="2"
           stroke-linecap="round"
           stroke-linejoin="round"
-          class="w-7 h-7"
+          class="w-5 h-5"
           aria-hidden="true"
         >
           <path d="M9.88 9.88a3 3 0 1 0 4.24 4.24" />
@@ -38,7 +46,6 @@ function reveal () {
           <path d="M6.61 6.61A13.526 13.526 0 0 0 2 12s3 7 10 7a9.74 9.74 0 0 0 5.39-1.61" />
           <line x1="2" y1="2" x2="22" y2="22" />
         </svg>
-        <span class="text-[10px] font-semibold uppercase tracking-wider">NSFW</span>
       </div>
     </div>
   </div>

--- a/frontend/components/post/PostCard.vue
+++ b/frontend/components/post/PostCard.vue
@@ -249,7 +249,7 @@ const hasLinkPreview = computed(() => {
 
           <!-- Video embed (YouTube or direct video) -->
           <ClientOnly>
-            <CommonNsfwBlur v-if="isYouTubeEmbed" :is-nsfw="post.isNSFW" class="mt-2 max-w-full sm:max-w-lg">
+            <CommonNsfwBlur v-if="isYouTubeEmbed" fluid :is-nsfw="post.isNSFW" class="mt-2 max-w-full sm:max-w-lg">
               <div class="rounded-lg overflow-hidden aspect-video">
                 <iframe
                   :src="post.embedVideoUrl!"
@@ -261,7 +261,7 @@ const hasLinkPreview = computed(() => {
                 />
               </div>
             </CommonNsfwBlur>
-            <CommonNsfwBlur v-else-if="isDirectVideo" :is-nsfw="post.isNSFW" class="mt-2 max-w-full sm:max-w-lg">
+            <CommonNsfwBlur v-else-if="isDirectVideo" fluid :is-nsfw="post.isNSFW" class="mt-2 max-w-full sm:max-w-lg">
               <video
                 :src="post.embedVideoUrl!"
                 class="w-full rounded-lg"
@@ -282,7 +282,7 @@ const hasLinkPreview = computed(() => {
           </CommonNsfwBlur>
 
           <!-- Post video (uploaded video file) -->
-          <CommonNsfwBlur v-if="isImageVideo" :is-nsfw="post.isNSFW" class="mt-2 max-w-full sm:max-w-lg">
+          <CommonNsfwBlur v-if="isImageVideo" fluid :is-nsfw="post.isNSFW" class="mt-2 max-w-full sm:max-w-lg">
             <video
               :src="post.image!"
               class="w-full rounded-lg"
@@ -303,12 +303,12 @@ const hasLinkPreview = computed(() => {
           </CommonNsfwBlur>
 
           <!-- Link preview card (for link posts without video) -->
-          <CommonNsfwBlur v-if="hasLinkPreview && post.url" :is-nsfw="post.isNSFW" class="mt-2">
+          <CommonNsfwBlur v-if="hasLinkPreview && post.url" fluid :is-nsfw="post.isNSFW" class="mt-2 max-w-full sm:max-w-lg">
             <a
               :href="post.url"
               target="_blank"
               rel="noopener noreferrer"
-              class="block border border-gray-200 rounded-lg overflow-hidden hover:border-gray-300 transition-colors no-underline max-w-full sm:max-w-lg"
+              class="block border border-gray-200 rounded-lg overflow-hidden hover:border-gray-300 transition-colors no-underline"
             >
               <div class="px-3 py-2">
                 <p v-if="post.embedTitle" class="text-sm font-medium text-gray-800 line-clamp-1">
@@ -323,11 +323,18 @@ const hasLinkPreview = computed(() => {
           </CommonNsfwBlur>
 
           <!-- Body preview (if text post) -->
-          <div
+          <CommonNsfwBlur
             v-if="post.bodyHTML && !post.url"
-            class="text-sm text-gray-500 line-clamp-2 mt-0.5 leading-relaxed prose prose-sm max-w-none [&>*]:m-0"
-            v-html="sanitizeHtml(post.bodyHTML)"
-          />
+            fluid
+            :is-nsfw="post.isNSFW"
+            class="block mt-0.5"
+          >
+            <!-- eslint-disable-next-line vue/no-v-html -->
+            <div
+              class="text-sm text-gray-500 line-clamp-2 leading-relaxed prose prose-sm max-w-none [&>*]:m-0"
+              v-html="sanitizeHtml(post.bodyHTML)"
+            />
+          </CommonNsfwBlur>
 
           <!-- Flags -->
           <div v-if="post.isNSFW || post.isLocked" class="flex items-center gap-2 mt-1">

--- a/frontend/components/post/PostDetail.vue
+++ b/frontend/components/post/PostDetail.vue
@@ -161,7 +161,7 @@ function onClickOutsideMenu (e: Event): void {
         </a>
 
         <!-- Video display (uploaded video file) -->
-        <CommonNsfwBlur v-if="post.image && isImageVideo" :is-nsfw="post.isNSFW" class="mt-3">
+        <CommonNsfwBlur v-if="post.image && isImageVideo" fluid :is-nsfw="post.isNSFW" class="mt-3 max-w-full">
           <video
             :src="post.image"
             class="max-w-full max-h-[400px] sm:max-h-[600px] rounded-lg border border-gray-200"
@@ -180,7 +180,7 @@ function onClickOutsideMenu (e: Event): void {
         </CommonNsfwBlur>
 
         <!-- Embed preview -->
-        <CommonNsfwBlur v-if="post.embedTitle || post.embedDescription" :is-nsfw="post.isNSFW" class="mt-3">
+        <CommonNsfwBlur v-if="post.embedTitle || post.embedDescription" fluid :is-nsfw="post.isNSFW" class="mt-3">
           <div class="border border-gray-200 rounded-lg p-3 bg-gray-50">
             <p v-if="post.embedTitle" class="text-sm font-medium text-gray-900">{{ post.embedTitle }}</p>
             <p v-if="post.embedDescription" class="text-xs text-gray-600 mt-1">{{ post.embedDescription }}</p>
@@ -229,11 +229,15 @@ function onClickOutsideMenu (e: Event): void {
         </div>
 
         <!-- Body -->
-        <!-- eslint-disable-next-line vue/no-v-html -->
-        <div v-if="post.bodyHTML" class="prose prose-sm mt-4 max-w-none" v-html="sanitizeHtml(post.bodyHTML)" />
-        <div v-else-if="post.body" class="prose prose-sm mt-4 max-w-none whitespace-pre-wrap">
-          {{ post.body }}
-        </div>
+        <CommonNsfwBlur v-if="post.bodyHTML" fluid :is-nsfw="post.isNSFW" class="block mt-4">
+          <!-- eslint-disable-next-line vue/no-v-html -->
+          <div class="prose prose-sm max-w-none" v-html="sanitizeHtml(post.bodyHTML)" />
+        </CommonNsfwBlur>
+        <CommonNsfwBlur v-else-if="post.body" fluid :is-nsfw="post.isNSFW" class="block mt-4">
+          <div class="prose prose-sm max-w-none whitespace-pre-wrap">
+            {{ post.body }}
+          </div>
+        </CommonNsfwBlur>
 
         <!-- Mobile inline votes -->
         <div class="sm:hidden mt-3">


### PR DESCRIPTION
…dies

- Drop redundant 'NSFW' caption from the overlay; the eye-off icon and the post's existing NSFW badge already convey the meaning.
- Size the NsfwBlur wrapper to its slot content by default so the icon overlays the actual blurred media instead of hovering in empty space beside it.
- Add a 'fluid' prop for slots whose children use w-full (videos, iframes, link preview cards, body text) so they keep block-level full-width behavior.
- Wrap post body text in NsfwBlur on NSFW text posts (PostCard preview and PostDetail full body) so text content is blurred too.
- Pass fluid through for video/iframe/embed/link-preview/body wrappers in PostCard and PostDetail.