### PR TITLE
feat(boards): label Feed/Forum sections on All tab

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -477,3 +477,6 @@ infallible `unwrap()` on date/time values.
 ### 2026-04-26 — NSFW Overlay Polish
 - Replaced the loud red "NSFW – Click to reveal" button in `components/common/NsfwBlur.vue` with a subtle eye-off icon. Content remains blurred and click-to-reveal; tooltip carries the reveal hint.
 - NsfwBlur wrapper now sizes to its slot content by default (`inline-block`) so the icon overlays the actual media rather than empty space beside it. Added a `fluid` prop for slots whose children use `w-full` (videos, iframes, link previews, body text) — those keep the block-level full-width behavior. Updated `PostCard.vue` and `PostDetail.vue` accordingly. Body preview text on NSFW text posts is now blurred too.
+
+### 2026-04-26 — Boards Directory: Feed/Forum Section Headers
+- On `/boards` with the "All" tab selected, feed and forum boards rendered back-to-back with only a 12px margin and no labels — the layout shift between grid cards and stacked rows looked unintentional. Added mode-themed section headers ("FEED BOARDS" in blue, "FORUM BOARDS" in purple) with counts and a tinted hairline divider. Headers only render when both groups are non-empty so single-mode result sets stay clean. Single-file change: `frontend/pages/boards/index.vue`.

--- a/frontend/pages/boards/index.vue
+++ b/frontend/pages/boards/index.vue
@@ -195,12 +195,33 @@ await fetchBoards()
     <!-- All: feed boards in grid, then forum boards in list -->
     <template v-else>
       <template v-if="filteredBoards.length > 0">
-        <div v-if="feedBoards.length > 0" class="grid gap-3 sm:grid-cols-2">
-          <BoardCard v-for="board in feedBoards" :key="board.id" :board="board" />
-        </div>
-        <div v-if="forumBoards.length > 0" class="space-y-2" :class="{ 'mt-3': feedBoards.length > 0 }">
-          <BoardCard v-for="board in forumBoards" :key="board.id" :board="board" />
-        </div>
+        <template v-if="feedBoards.length > 0">
+          <div v-if="forumBoards.length > 0" class="mb-3 flex items-center gap-2">
+            <span class="text-xs font-semibold uppercase tracking-wider text-blue-700">
+              Feed Boards
+            </span>
+            <span class="text-xs text-gray-400">{{ feedBoards.length }}</span>
+            <div class="flex-1 h-px bg-blue-100"></div>
+          </div>
+          <div class="grid gap-3 sm:grid-cols-2">
+            <BoardCard v-for="board in feedBoards" :key="board.id" :board="board" />
+          </div>
+        </template>
+        <template v-if="forumBoards.length > 0">
+          <div
+            v-if="feedBoards.length > 0"
+            class="mt-6 mb-3 flex items-center gap-2"
+          >
+            <span class="text-xs font-semibold uppercase tracking-wider text-purple-700">
+              Forum Boards
+            </span>
+            <span class="text-xs text-gray-400">{{ forumBoards.length }}</span>
+            <div class="flex-1 h-px bg-purple-100"></div>
+          </div>
+          <div class="space-y-2">
+            <BoardCard v-for="board in forumBoards" :key="board.id" :board="board" />
+          </div>
+        </template>
       </template>
       <p v-else class="text-sm text-gray-500 text-center py-8">No boards found.</p>
     </template>


### PR DESCRIPTION
When the boards directory's All tab mixed feed and forum boards, the layout shift from a 2-column card grid to a stacked list looked like a glitch rather than intentional grouping. Add mode-themed section headers (blue for Feed, purple for Forum) with counts and a tinted hairline divider. Headers only render when both groups are non-empty so single-mode result sets stay unchanged.