### PR TITLE
fix(reactions): enlarge emoji and fix pill clipping on reaction chips

### DIFF
--- a/frontend/assets/css/main.css
+++ b/frontend/assets/css/main.css
@@ -16,8 +16,8 @@
 /* Custom emoji styles — Discord-like sizing */
 img.emoji {
   display: inline-block;
-  width: 1.875em;
-  height: 1.875em;
+  width: 2.25em;
+  height: 2.25em;
   vertical-align: middle;
   margin: 0 0.1em;
   object-fit: contain;
@@ -26,8 +26,8 @@ img.emoji {
 
 /* Jumbo emoji: when a message contains only emoji(s), render them larger */
 .emoji-jumbo img.emoji {
-  width: 3em;
-  height: 3em;
+  width: 3.5em;
+  height: 3.5em;
 }
 
 @layer base {

--- a/frontend/components/common/ReactionBar.vue
+++ b/frontend/components/common/ReactionBar.vue
@@ -125,7 +125,7 @@ async function handlePickerSelect (entry: ReactionEmojiEntry): Promise<void> {
     <button
       v-for="r in reactions"
       :key="r.emoji"
-      class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-sm border transition-colors"
+      class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-sm border transition-colors leading-none"
       :class="r.reacted
         ? 'border-primary/30 bg-primary/5 text-primary'
         : 'border-gray-200 bg-white text-gray-600 hover:border-gray-300'"
@@ -136,16 +136,16 @@ async function handlePickerSelect (entry: ReactionEmojiEntry): Promise<void> {
         v-if="isCustomEmoji(r.emoji) && getCustomEmojiUrl(r.emoji)"
         :src="getCustomEmojiUrl(r.emoji)"
         :alt="r.emoji"
-        class="w-6 h-6 object-contain"
+        class="w-7 h-7 object-contain shrink-0"
       />
-      <span v-else class="text-base leading-none">{{ r.emoji }}</span>
+      <span v-else class="text-lg leading-none">{{ r.emoji }}</span>
       <span class="font-medium text-xs">{{ r.count }}</span>
     </button>
 
     <!-- Add reaction button -->
     <div v-if="authStore.isLoggedIn" class="relative">
       <button
-        class="inline-flex items-center px-1.5 py-0.5 rounded-full text-xs border border-dashed border-gray-300 text-gray-400 hover:text-gray-600 hover:border-gray-400 transition-colors"
+        class="inline-flex items-center justify-center w-9 h-9 rounded-full text-sm border border-dashed border-gray-300 text-gray-400 hover:text-gray-600 hover:border-gray-400 transition-colors"
         :disabled="acting"
         @click="showPicker = !showPicker"
       >

--- a/frontend/pages/inbox/messages/[id].vue
+++ b/frontend/pages/inbox/messages/[id].vue
@@ -218,8 +218,8 @@ await fetchMessages()
 }
 .message-body :deep(img.emoji) {
   display: inline-block;
-  width: 1.875em;
-  height: 1.875em;
+  width: 2.25em;
+  height: 2.25em;
   vertical-align: middle;
 }
 .message-bubble--own .message-body :deep(a) {


### PR DESCRIPTION
- Bump custom emoji size in body content to 2.25em (was 1.875em).
- Reaction chips: increase padding (px-2.5 py-1), gap, and emoji slot to w-7 h-7 (28px) so the larger emojis no longer get clipped by the rounded-full border. Unicode emoji bumped to text-lg.
- Add-reaction button reshaped to a 36px circular target to match the new chip height.