### PR TITLE
fix(messages): expose PrivateMessage.body_html as bodyHTML

### DIFF
--- a/backend/crates/api/src/structs/message.rs
+++ b/backend/crates/api/src/structs/message.rs
@@ -18,6 +18,7 @@ pub struct PrivateMessage {
     pub recipient_id: Option<ID>,
     pub subject: Option<String>,
     pub body: String,
+    #[graphql(name = "bodyHTML")]
     pub body_html: String,
     pub is_read: bool,
     pub is_sender_hidden: bool,


### PR DESCRIPTION
async_graphql defaulted to bodyHtml, which broke the conversation page that queried bodyHTML. Match the Comment struct's explicit rename.